### PR TITLE
Text rendering

### DIFF
--- a/Classes/Ejecta/EJCanvas/EJFont.m
+++ b/Classes/Ejecta/EJCanvas/EJFont.m
@@ -119,7 +119,7 @@ typedef struct _tagStringLayout {
 }
 
 - (double)widthForLayout {
-	return CTLineGetTypographicBounds(_ctLine, NULL, NULL, NULL);
+	return PT_TO_PX(CTLineGetTypographicBounds(_ctLine, NULL, NULL, NULL));
 }
 
 - (void)releaseLayout


### PR DESCRIPTION
I've fixed a small bug that kept newly generated glyphs from appearing in the first frame.

And I've cleaned up & restructured the algorithm so that new glyphs are generated in batches (e.g. all new glyphs in a string are added at the same time) - improves loading speed in my test cases by around ~300%.

.. and I really begin to hate the word `glyph`. For some reason I misspell it almost every time. Fortunately I'm done for now.
