### PR TITLE
added stencil test for transparent lines

### DIFF
--- a/Classes/Ejecta/EJCanvas/EJPath.mm
+++ b/Classes/Ejecta/EJCanvas/EJPath.mm
@@ -403,22 +403,16 @@ typedef std::vector<subpath_t> path_t;
 	[self endSubPath];
 	
 	EJCanvasState * state = context.state;
+	EJVector2 vecZero = { 0.0f, 0.0f };
 	
 	// Find the width of the line as it is projected onto the screen.
 	float projectedLineWidth = CGAffineTransformGetScale( state->transform ) * state->lineWidth;
-	[context setLineTextureForWidth:projectedLineWidth];
+	[context setTexture:NULL];
 	
 	// Figure out if we need to add line caps and set the cap texture coord for square or round caps.
 	// For thin lines we disable texturing and line caps.
 	float width2 = state->lineWidth/2;
 	BOOL addCaps = (projectedLineWidth > 2 && (state->lineCap == kEJLineCapRound || state->lineCap == kEJLineCapSquare));
-	
-	float capTexXCoord = (state->lineCap == kEJLineCapRound) ? 0.0f : 0.5f;
-	EJVector2 capTex1 = { capTexXCoord, 0 };
-	EJVector2 capTex2 = { capTexXCoord, 1 };
-	
-	EJVector2 midTex1 = { 0.5, 0 };
-	EJVector2 midTex2 = { 0.5, 1 };
 	
 	// The miter limit is the maximum allowed ratio of the miter length to half the line width.
 	// For thin lines we skip computing the miter completely.
@@ -428,6 +422,17 @@ typedef std::vector<subpath_t> path_t;
 	EJColorRGBA color = state->strokeColor;
 	color.rgba.a = (float)color.rgba.a * state->globalAlpha;
 	
+	// enable stencil test when drawing transparent lines
+	if(color.rgba.a < 0xff) {
+		[context createStencilBufferOnce];
+		
+		glEnable(GL_STENCIL_TEST);
+		
+		glStencilMask(0x01);
+		
+		glStencilOp(GL_KEEP, GL_KEEP, GL_INCR);
+		glStencilFunc(GL_NOTEQUAL, 0x1, 0x1);
+	}
 	
 	// To draw the line correctly with transformations, we need to construct the line
 	// vertices from the untransformed points and only apply the transformation in
@@ -502,7 +507,7 @@ typedef std::vector<subpath_t> path_t;
 						
 						[context
 							 pushQuadV1:cap11 v2:cap12 v3:miter21 v4:miter22
-							 t1:capTex1 t2:capTex2 t3:midTex1 t4:midTex2
+							 t1:vecZero t2:vecZero t3:vecZero t4:vecZero
 							 color:color withTransform:transform];
 					} else {
 						[self drawArcToContext:context atPoint:current v1:miter22 v2:miter21 color:color];
@@ -580,7 +585,7 @@ typedef std::vector<subpath_t> path_t;
 
 			[context
 				pushQuadV1:miter11 v2:miter12 v3:miter21 v4:miter22
-				t1:midTex1 t2:midTex2 t3:midTex1 t4:midTex2
+				t1:vecZero t2:vecZero t3:vecZero t4:vecZero
 				color:color withTransform:transform];
 
 			// No miter added? The "miter" for the next segment needs to be the butt for the next segment,
@@ -633,7 +638,7 @@ typedef std::vector<subpath_t> path_t;
 
 		[context
 			pushQuadV1:miter11 v2:miter12 v3:miter21 v4:miter22
-			t1:midTex1 t2:midTex2 t3:midTex1 t4:midTex2
+			t1:vecZero t2:vecZero t3:vecZero t4:vecZero
 			color:color withTransform:transform];		
 
 		// End cap
@@ -645,13 +650,22 @@ typedef std::vector<subpath_t> path_t;
 				
 				[context
 					pushQuadV1:cap11 v2:cap12 v3:miter11 v4:miter12
-					t1:capTex1 t2:capTex2 t3:midTex1 t4:midTex2
+					t1:vecZero t2:vecZero t3:vecZero t4:vecZero
 					color:color withTransform:transform];
 			} else {
 				[self drawArcToContext:context atPoint:next v1:miter11 v2:miter12 color:color];
 			}
 		}
 	} // for each path
+	
+	// disable stencil test when drawing transparent lines
+	if(color.rgba.a<0xff) {
+		[context flushBuffers];
+		glDisable(GL_STENCIL_TEST);
+		
+		glClearStencil(0);
+		glClear(GL_STENCIL_BUFFER_BIT);
+	}
 }
 
 


### PR DESCRIPTION
Here's a simple implementation of using the stencil buffer to disable overdraw/overlapping in `stroke`.
I had to disable the line textures for this to work, as it requires all pixels to be of the same color.

Our two examples:
![image](http://f.cl.ly/items/1W2Q3R3V0G1a0S3p3K1D/Screen%20Shot%202012-10-05%20at%208.42.03%20PM.png)

``` javascript
var canvas = document.getElementById('canvas');
var ctx = canvas.getContext('2d');

ctx.lineWidth = 11;
ctx.lineJoin = 'bevel';
ctx.lineCap = 'round';
ctx.globalAlpha = 0.5;
ctx.strokeStyle = '#fff';

ctx.beginPath();
ctx.moveTo(100, 200 );
ctx.lineTo(200, 250 );
ctx.lineTo(100, 320 );
ctx.lineTo(100, 350 );
ctx.bezierCurveTo( 100, 370, 130, 450, 200, 400 );

ctx.stroke();

ctx.beginPath();

ctx.translate(200,200);
ctx.scale(0.5,0.5);

ctx.moveTo(50, 350 );
ctx.lineTo(50, 50 );
ctx.lineTo(100, 50 );
ctx.lineTo(100, 150 );
ctx.lineTo(0, 150 );

ctx.stroke();
```
