### PR TITLE
improved performance when stroking transparent lines

### DIFF
--- a/Classes/Ejecta/EJCanvas/EJPath.h
+++ b/Classes/Ejecta/EJCanvas/EJPath.h
@@ -12,6 +12,8 @@
 	EJVector2 currentPos, startPos;
 	int longestSubpath;
 	
+	GLubyte stencilMask;
+	
 	EJVector2 * vertexBuffer;
 	int vertexBufferLength;
 	


### PR DESCRIPTION
I did a small change to the stencil buffer usage in stroke.
By rotating through the 7 highest bits, it is enough to only do one glClear after 7 strokes, instead of after one. As `fill` only uses the lowest bit, this change has no effect  on the behaviour of `fill`.

Performance goes up from 3 fps to 16fps in the index.js with 4xMSAA and 200 curves on my ipad3.

For other cases an interesting further optimization might be to also compute the bounds of all 7 stroked paths, join them, and push a rect instead of doing a clear.. when only small areas of the screen are affected, that might help :)
