### PR TITLE
Missing flush call

### DIFF
--- a/Classes/Ejecta/EJCanvas/EJPath.mm
+++ b/Classes/Ejecta/EJCanvas/EJPath.mm
@@ -436,6 +436,7 @@ typedef std::vector<subpath_t> path_t;
 	if(color.rgba.a < 0xff) {
 		stencilMask <<= 1;
 		
+		[context flushBuffers];
 		[context createStencilBufferOnce];
 		
 		glEnable(GL_STENCIL_TEST);


### PR DESCRIPTION
Added a call to flushBuffers before activating the stencil test in `drawLinesToContext`.
