### PR TITLE
Check for missing textEncodingName

### DIFF
--- a/Classes/Ejecta/EJUtils/EJBindingHttpRequest.m
+++ b/Classes/Ejecta/EJUtils/EJBindingHttpRequest.m
@@ -35,9 +35,11 @@
 	if( !response || !responseBody ) { return NULL; }
 	
 	NSStringEncoding encoding = NSASCIIStringEncoding;
-	CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef) [response textEncodingName]);
-	if( cfEncoding != kCFStringEncodingInvalidId ) {
-		encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+	if ( response.textEncodingName ) {
+		CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef) [response textEncodingName]);
+		if( cfEncoding != kCFStringEncodingInvalidId ) {
+			encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+		}
 	}
 
 	return [[[NSString alloc] initWithData:responseBody encoding:encoding] autorelease];


### PR DESCRIPTION
HTTP request will crash if the response's textEncodingName is missing - which occurs when the server doesn't specify a mime type.

(I don't know if you prefer us to just write an issue, or send a pull requests for kind of one-liner)
