### PR TITLE
Make the canvas transparent

### DIFF
--- a/Classes/Ejecta/EJCanvas/EAGLView.m
+++ b/Classes/Ejecta/EJCanvas/EAGLView.m
@@ -12,12 +12,16 @@
 - (id)initWithFrame:(CGRect)frame contentScale:(float)contentScale {
 	if( self = [super initWithFrame:frame] ) {
 		[self setMultipleTouchEnabled:YES];
+        [self setBackgroundColor:[UIColor clearColor]];
+        [self setOpaque:NO];
+        
         CAEAGLLayer *eaglLayer = (CAEAGLLayer *)self.layer;
 		
 		self.contentScaleFactor = contentScale;
 		eaglLayer.contentsScale = contentScale;
         
-        eaglLayer.opaque = TRUE;
+        eaglLayer.opaque = FALSE;
+        eaglLayer.backgroundColor = [[UIColor clearColor] CGColor];
         eaglLayer.drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys:
                                         [NSNumber numberWithBool:TRUE], kEAGLDrawablePropertyRetainedBacking,
                                         kEAGLColorFormatRGBA8, kEAGLDrawablePropertyColorFormat,


### PR DESCRIPTION
Making the EAGLView transparent allows us to easily layer a UIWebView on top or below of the main Ejecta canvas.

The example application, `index.js`, appears to be unaffected. There might be some performance problems I haven't considered, though.
