### PR TITLE
Modify assert to allow "drawing" empty string

### DIFF
--- a/Classes/Ejecta/EJCanvas/EJFont.m
+++ b/Classes/Ejecta/EJCanvas/EJFont.m
@@ -124,7 +124,7 @@ int TextureToGlyphSort(const void * a, const void * b) {
 	CFArrayRef glyphRuns = CTLineGetGlyphRuns(_ctLine);
 	CFIndex runCount = CFArrayGetCount(glyphRuns);
 	
-	assert(runCount==1); // line should only require one run, because we use one font and no attributes
+	assert(runCount<=1); // line require at most one run, because we use one font and no attributes
 	
 	CTRunRef run = CFArrayGetValueAtIndex(glyphRuns, 0);
 	CFIndex glyphCount = CTRunGetGlyphCount(run);


### PR DESCRIPTION
If you pass an empty string to fillText it would crash on the assert. Allowing a 0 runCount works correctly (though it might be better to just return from the function immediately if the string is empty).
