### PR TITLE
createImageData() pixel allocation change from malloc() to calloc()

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -406,7 +406,7 @@ EJ_BIND_FUNCTION(createImageData, ctx, argc, argv) {
 		sw = JSValueToNumberFast(ctx, argv[0]),
 		sh = JSValueToNumberFast(ctx, argv[1]);
 		
-	GLubyte * pixels = malloc( sw * sh * 4 * sizeof(GLubyte));
+	GLubyte * pixels = calloc( sw * sh * 4, sizeof(GLubyte) );
 	EJImageData * imageData = [[[EJImageData alloc] initWithWidth:sw height:sh pixels:pixels] autorelease];
 	
 	// Create the JS object


### PR DESCRIPTION
The problem with malloc() was that calling createImageData() repeatedly
caused it to return an ImageData object which contained pixel data that was
set to the previously returned ImageData object.

createImageData() should always return an object filled with transparent black,
calloc() achieves this by automatically filling the allocated space with zeroes.
