### PR TITLE
remove AppDelegate import from EJJavaScriptView

### DIFF
--- a/Source/Ejecta/EJJavaScriptView.m
+++ b/Source/Ejecta/EJJavaScriptView.m
@@ -4,8 +4,6 @@
 #import "EJClassLoader.h"
 #import <objc/runtime.h>
 
-#import "AppDelegate.h"
-
 
 @implementation EJNonRetainingProxy
 + (EJNonRetainingProxy *)nonRetainingProxyWithTarget:(id)target {


### PR DESCRIPTION
We are bundling as a library and have excluded the AppDelegate from the source files which causes an import error, this removes the AppDelegate import (unused in EJJavaScriptView so does not affect anything)
