### PR TITLE
Autosize the eaglview to adjust to the size of the EJJavaScriptView

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2DScreen.m
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2DScreen.m
@@ -47,7 +47,8 @@
 	
 	// Create the OpenGL UIView with final screen size and content scaling (retina)
 	glview = [[EAGLView alloc] initWithFrame:frame contentScale:contentScale retainedBacking:YES];
-	
+    glview.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+
 	// This creates the frame- and renderbuffers
 	[super create];
 	


### PR DESCRIPTION
Set's `autoresizingMask` to `UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth` on the `EJCanvasContext2DScreen`'s `EAGLView`, which auto-adjusts the size of the `EAGLView` when the frame of `EJJavaScriptView` changes.

Not sure how this is handled down in the JavaScript, maybe have an event listener for when the frame size changes?
