### PR TITLE
Remove ceilf() call when measuring a string

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJFont.mm
+++ b/Source/Ejecta/EJCanvas/2D/EJFont.mm
@@ -416,7 +416,7 @@ int EJFontGlyphLayoutSortByTextureIndex(const void *a, const void *b) {
 	float yOffset = [self getYOffsetForBaseline:context.state->textBaseline];
 	EJTextMetrics metrics = [self getLayoutForString:string].metrics;
 	
-	metrics.width = ceilf(metrics.width);
+	metrics.width = metrics.width;
 	metrics.ascent += yOffset;
 	metrics.descent += yOffset;
 	


### PR DESCRIPTION
This brings Ejecta's measureText return value in line with browsers. While integers values may render smoother/crisper, you can continue to use rounding (if desired) in your implementation.
