### PR TITLE
Retain timer when it is being checked to prevent it from being released ...

### DIFF
--- a/Source/Ejecta/EJTimer.m
+++ b/Source/Ejecta/EJTimer.m
@@ -33,12 +33,13 @@
 
 - (void)update {	
 	for( NSNumber *timerId in [timers allKeys]) {
-		EJTimer *timer = timers[timerId];
+		EJTimer *timer = [timers[timerId] retain];
 		[timer check];
 		
 		if( !timer.active ) {
 			[timers removeObjectForKey:timerId];
-		}		
+		}
+        [timer release];
 	}
 }
 


### PR DESCRIPTION
...and then referenced. Resolves issue #138

This is for issue #138

during enumeration, `[timer check]` is being called which can cause the timer to be cancelled, and thus removed from the dictionary, deallocating it. `timer` was then being referenced at the end of the loop, causing a crash. This resolves the issue by retaining `timer` while it's in the loop.
