### PR TITLE
When switching contexts reset frame/render buffer bindings to the last buffers bound in script

### DIFF
--- a/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
@@ -308,6 +308,7 @@ EJ_BIND_FUNCTION(bindBuffer, ctx, argc, argv) {
 		else { \
 			[renderingContext bind##NAME]; \
 		} \
+		renderingContext.bound##NAME = index; \
 		return NULL; \
 	}
 

--- a/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.h
+++ b/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.h
@@ -7,6 +7,9 @@
 	GLuint viewFrameBuffer, viewRenderBuffer;
 	GLuint depthRenderBuffer;
 	
+	GLuint boundFramebuffer;
+	GLuint boundRenderbuffer;
+	
 	GLint bufferWidth, bufferHeight;
 	EAGLView *glview;
 	EJJavaScriptView *scriptView;
@@ -30,5 +33,8 @@
 @property (nonatomic) BOOL needsPresenting;
 @property (nonatomic) BOOL useRetinaResolution;
 @property (nonatomic,readonly) float backingStoreRatio;
+
+@property (nonatomic) GLuint boundFramebuffer;
+@property (nonatomic) GLuint boundRenderbuffer;
 
 @end

--- a/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.m
@@ -7,6 +7,9 @@
 @synthesize useRetinaResolution;
 @synthesize backingStoreRatio;
 
+@synthesize boundFramebuffer;
+@synthesize boundRenderbuffer;
+
 - (BOOL)needsPresenting { return needsPresenting; }
 - (void)setNeedsPresenting:(BOOL)needsPresentingp { needsPresenting = needsPresentingp; }
 
@@ -29,6 +32,9 @@
 		
 		msaaEnabled = NO;
 		msaaSamples = 2;
+		
+		boundFramebuffer = 0;
+		boundRenderbuffer = 0;
 	}
 	return self;
 }
@@ -155,9 +161,12 @@
 	[super dealloc];
 }
 
-- (void)prepare {	
-	glBindFramebuffer(GL_FRAMEBUFFER, viewFrameBuffer);
-	glBindRenderbuffer(GL_RENDERBUFFER, viewRenderBuffer);
+- (void)prepare {
+	// Bind to the frame/render buffer last bound on this context
+	GLuint framebuffer = boundFramebuffer ? boundFramebuffer : viewFrameBuffer;
+	GLuint renderbuffer = boundRenderbuffer ? boundRenderbuffer : viewRenderBuffer;
+	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	glBindRenderbuffer(GL_RENDERBUFFER, renderbuffer);
 	
 	// Re-bind textures; they may have been changed in a different context
 	GLint boundTexture2D;
@@ -195,7 +204,6 @@
 	if( !needsPresenting ) { return; }
 	
 	[glContext presentRenderbuffer:GL_RENDERBUFFER];
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	needsPresenting = NO;
 }
 


### PR DESCRIPTION
2 changes - Properly reset frame/render buffers in "prepare". Remove glClear from "present"

This is to fix an issue found while porting a Construct 2 sample with WebGL renderer.

https://dl.dropbox.com/u/24635762/construct2_rain_demo.zip

When the context switches back to the WebGL context it is always bound to the view frame and render buffers instead of the last frame / render buffers bound in code. The sample tries to delete the texture attached an offscreen Fbo but since because of context switches it resets the main frame buffer leaving it with no color buffer, resulting in an empty screen.

I have verified this change fixes the issue. Also trying to do a glGetIntegerv( GL_FRAMEBUFFER_BINDING, ... ) just before resetting the framebuffer didn't seem to work. I am guessing this information is lost during the context switch. I didn't change the resize code which uses glGetIntegerv since I didn't have a test case to test it with.

I have also removed the glClear in "present" after presenting the render buffer. This is not a functionality fix but just to remove an extra call which I think is unneeded. The presenRender buffer document seems to indicate that this is already done by the API and setting the kEAGLDrawablePropertyRetainedBacking key will have the effect required by preserveDrawingBuffer - http://developer.apple.com/library/ios/#documentation/OpenGLES/Reference/EAGLContext_ClassRef/Reference/EAGLContext.html#//apple_ref/occ/instm/EAGLContext/presentRenderbuffer:
