### PR TITLE
Add scale property to TouchEvents

### DIFF
--- a/Source/Ejecta/EJJavaScriptView.h
+++ b/Source/Ejecta/EJJavaScriptView.h
@@ -17,7 +17,7 @@
 
 
 @protocol EJTouchDelegate
-- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining;
+- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining scale:(float)scale;
 @end
 
 @protocol EJDeviceMotionDelegate

--- a/Source/Ejecta/EJUtils/EJBindingTouchInput.h
+++ b/Source/Ejecta/EJUtils/EJBindingTouchInput.h
@@ -11,6 +11,6 @@
 	JSObjectRef jsTouchesPool[EJ_TOUCH_INPUT_MAX_TOUCHES];
 }
 
-- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining;
+- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining scale:(float)scale;
 
 @end

--- a/Source/Ejecta/EJUtils/EJBindingTouchInput.m
+++ b/Source/Ejecta/EJUtils/EJBindingTouchInput.m
@@ -44,7 +44,7 @@
 	JSStringRelease( jsPageYName );
 	JSStringRelease( jsClientXName );
 	JSStringRelease( jsClientYName );
-	
+
 	for( int i = 0; i < EJ_TOUCH_INPUT_MAX_TOUCHES; i++ ) {
 		JSValueUnprotectSafe( ctx, jsTouchesPool[i] );
 	}
@@ -52,7 +52,7 @@
 	[super dealloc];
 }
 
-- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining {
+- (void)triggerEvent:(NSString *)name all:(NSSet *)all changed:(NSSet *)changed remaining:(NSSet *)remaining scale:(float)scale {
 	JSContextRef ctx = scriptView.jsGlobalContext;
 	
 	JSObjectSetProperty(ctx, jsRemainingTouches, jsLengthName, JSValueMakeNumber(ctx, remaining.count), kJSPropertyAttributeNone, NULL);
@@ -88,7 +88,7 @@
 		if( poolIndex >= EJ_TOUCH_INPUT_MAX_TOUCHES ) { break; }
 	}
 	
-	[self triggerEvent:name argc:2 argv:(JSValueRef[]){ jsRemainingTouches, jsChangedTouches }];
+	[self triggerEvent:name argc:3 argv:(JSValueRef[]){ jsRemainingTouches, jsChangedTouches, JSValueMakeNumber(ctx, scale)}];
 }
 
 EJ_BIND_EVENT(touchstart);

--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -219,14 +219,17 @@ var touchEvent = {
 	targetTouches: null,
 	changedTouches: null,
 	preventDefault: function(){},
-	stopPropagation: function(){}
+	stopPropagation: function(){},
+	scale: 1.0
 };
 
-var publishTouchEvent = function( type, all, changed ) {
+var publishTouchEvent = function( type, all, changed, scale ) {
 	touchEvent.touches = all;
 	touchEvent.targetTouches = all;
 	touchEvent.changedTouches = changed;
 	touchEvent.type = type;
+ 
+	touchEvent.scale = scale;
 	
 	document._publishEvent( touchEvent );
 };
@@ -234,9 +237,9 @@ eventInit.touchstart = eventInit.touchend = eventInit.touchmove = function() {
 	if( touchInput ) { return; }
 
 	touchInput = new Ejecta.TouchInput();
-	touchInput.ontouchstart = function( all, changed ){ publishTouchEvent( 'touchstart', all, changed ); };
-	touchInput.ontouchend = function( all, changed ){ publishTouchEvent( 'touchend', all, changed ); };
-	touchInput.ontouchmove = function( all, changed ){ publishTouchEvent( 'touchmove', all, changed ); };
+	touchInput.ontouchstart = function( all, changed, scale ){ publishTouchEvent( 'touchstart', all, changed, scale ); };
+	touchInput.ontouchend = function( all, changed, scale ){ publishTouchEvent( 'touchend', all, changed, scale ); };
+	touchInput.ontouchmove = function( all, changed, scale ){ publishTouchEvent( 'touchmove', all, changed, scale ); };
 };
 
 


### PR DESCRIPTION
This makes it easier to recognize pinch to zoom gesture on JS side.

The `scale` property is non-standard but Apple implements in Mobile Safari, see
http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/TouchEventClassReference/TouchEvent/TouchEvent.html#//apple_ref/doc/uid/TP40009358

What do you think? This pull request might not be mergeable as is, it's more like an opener for discussion.