### PR TITLE
Fix textBaseline 'top' and 'middle'

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJFont.h
+++ b/Source/Ejecta/EJCanvas/2D/EJFont.h
@@ -68,7 +68,7 @@ int EJFontGlyphLayoutSortByTextureIndex(const void *a, const void *b);
 	float txLineX, txLineY, txLineH;
 	
 	// Font preferences
-	float pointSize, ascent, ascentDelta, descent, leading, lineHeight, contentScale, glyphPadding;
+	float pointSize, ascent, descent, leading, contentScale, glyphPadding;
 	BOOL fill;
 	float lineWidth;
 	

--- a/Source/Ejecta/EJCanvas/2D/EJFont.mm
+++ b/Source/Ejecta/EJCanvas/2D/EJFont.mm
@@ -97,14 +97,6 @@ int EJFontGlyphLayoutSortByTextureIndex(const void *a, const void *b) {
 			leading	= CTFontGetLeading(ctMainFont);
 			ascent = CTFontGetAscent(ctMainFont);
 			descent = CTFontGetDescent(ctMainFont);
-			lineHeight = leading + ascent + descent;
-			if( leading == 0 ) {
-				ascentDelta = floor (0.2 * lineHeight + 0.5);
-				lineHeight += ascentDelta;
-			}
-			else {
-				ascentDelta = 0.0f;
-			}
 			
 			textures = [[NSMutableArray alloc] initWithCapacity:1];
 			layoutCache = [[NSCache alloc] init];
@@ -357,9 +349,9 @@ int EJFontGlyphLayoutSortByTextureIndex(const void *a, const void *b) {
 			return 0;
 		case kEJTextBaselineTop:
 		case kEJTextBaselineHanging:
-			return (ascent + ascentDelta);
+			return ascent;
 		case kEJTextBaselineMiddle:
-			return (ascent - 0.5 * pointSize);
+			return (ascent - descent)/2;
 		case kEJTextBaselineBottom:
 			return -descent;
 	}


### PR DESCRIPTION
I fixed context.textBaseline options for 'top' and 'middle' and removed some unused variables.
