### PR TITLE
Added window.addEventListener('resize') functionality.

### DIFF
--- a/Source/Ejecta/EJBindingEjectaCore.h
+++ b/Source/Ejecta/EJBindingEjectaCore.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "EJBindingBase.h"
+#import "EJBindingEventedBase.h"
 #import "EJFont.h"
 
 enum {
@@ -7,7 +7,7 @@ enum {
 	kEJCoreAlertViewGetText
 };
 
-@interface EJBindingEjectaCore : EJBindingBase {
+@interface EJBindingEjectaCore : EJBindingEventedBase {
 	NSString *urlToOpen;
 	JSObjectRef getTextCallback;
 	NSString *deviceName;

--- a/Source/Ejecta/EJBindingEjectaCore.m
+++ b/Source/Ejecta/EJBindingEjectaCore.m
@@ -8,6 +8,19 @@
 
 @implementation EJBindingEjectaCore
 
+- (void)createWithJSObject:(JSObjectRef)obj scriptView:(EJJavaScriptView *)view {
+    [super createWithJSObject:obj scriptView:view];
+    
+    [view addObserver:self forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:NULL];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if (object == self.scriptView && [keyPath isEqualToString:@"frame"]) {
+        [self triggerEvent:@"resize" argc:0 argv:NULL];
+    }
+}
+
 - (NSString*) deviceName {
 	struct utsname systemInfo;
 	uname( &systemInfo );
@@ -30,13 +43,14 @@
 
 - (void)dealloc {
 	[urlToOpen release];
+    [self.scriptView removeObserver:self forKeyPath:@"frame"];
 	JSValueUnprotectSafe(scriptView.jsGlobalContext, getTextCallback);
 	[super dealloc];
 }
 
 EJ_BIND_FUNCTION(log, ctx, argc, argv ) {
 	if( argc < 1 ) return NULL;
-	
+    
 	NSLog( @"JS: %@", JSValueToNSString(ctx, argv[0]) );
 	return NULL;
 }

--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -335,5 +335,17 @@ eventInit.pagehide = eventInit.pageshow = function() {
 		}
 	}
 };
+ 
+ej.addEventListener('resize', function () {
+    window.innerWidth = ej.screenWidth;
+    window.innerHeight = ej.screenHeight;
+    var resizeEvent = {
+        type: 'resize',
+        target: window,
+         preventDefault: function(){},
+         stopPropagation: function(){}
+    };
+    document._publishEvent(resizeEvent);
+});
 
 })(this);


### PR DESCRIPTION
This PR add's resize functionality for window.resize event listeners.

On resize it also updates the window.innerWidth and window.innerHeight.

Notable changes are that I had to change `EJBindingEjectaCore`'s base class to `EJBindingEventedBase` in order to get this to trigger the resize event when the frame of the EJJavaScriptView changes

thanks!
