### PR TITLE
Adding window.top for better browser compatibility

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -6,6 +6,7 @@
 
 // Make 'window' the global scope
 self = window = this;
+window.top = window;
 
 (function(window) {
 


### PR DESCRIPTION
This adds support for window.top. Which is basically window in the case of Ejecta.
