### PR TITLE
Adding support for window.parent

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -6,7 +6,7 @@
 
 // Make 'window' the global scope
 self = window = this;
-window.top = window;
+window.top = window.parent = window;
 
 (function(window) {
 


### PR DESCRIPTION
In a browser, window.parent always === window at the topmost window. In
the case of Ejecta, since there will never be subwindows or frames, setting
window.parent to window is good enough.

For more information:

https://developer.mozilla.org/en-US/docs/Web/API/window.parent
