### PR TITLE
add some composites

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
@@ -38,7 +38,14 @@ EJ_BIND_ENUM(globalCompositeOperation, renderingContext.globalCompositeOperation
 	"destination-out",	// kEJCompositeOperationDestinationOut
 	"destination-over",	// kEJCompositeOperationDestinationOver
 	"source-atop",		// kEJCompositeOperationSourceAtop
-	"xor"				// kEJCompositeOperationXOR
+	"xor",				// kEJCompositeOperationXOR
+             
+    "destination-in",	// kEJCompositeOperationDestinationIn
+    "source-in",        // kEJCompositeOperationSourceIn
+    "source-out",       // kEJCompositeOperationSourceOut
+    "destination-atop", // kEJCompositeOperationDestinationAtop
+    "copy"              // kEJCompositeOperationCopy
+
 );
 
 EJ_BIND_ENUM(lineCap, renderingContext.state->lineCap,

--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
@@ -45,7 +45,13 @@ typedef enum {
 	kEJCompositeOperationDestinationOut,
 	kEJCompositeOperationDestinationOver,
 	kEJCompositeOperationSourceAtop,
-	kEJCompositeOperationXOR
+	kEJCompositeOperationXOR,
+    
+    kEJCompositeOperationDestinationIn,
+    kEJCompositeOperationSourceIn,
+    kEJCompositeOperationSourceOut,
+    kEJCompositeOperationDestinationAtop,
+    kEJCompositeOperationCopy
 } EJCompositeOperation;
 
 typedef struct { GLenum source; GLenum destination; float alphaFactor; } EJCompositeOperationFunc;

--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.m
@@ -14,7 +14,13 @@ const EJCompositeOperationFunc EJCompositeOperationFuncs[] = {
 	[kEJCompositeOperationDestinationOut] = {GL_ZERO, GL_ONE_MINUS_SRC_ALPHA, 1},
 	[kEJCompositeOperationDestinationOver] = {GL_ONE_MINUS_DST_ALPHA, GL_ONE, 1},
 	[kEJCompositeOperationSourceAtop] = {GL_DST_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1},
-	[kEJCompositeOperationXOR] = {GL_ONE_MINUS_DST_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1}
+	[kEJCompositeOperationXOR] = {GL_ONE_MINUS_DST_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1},
+    
+    [kEJCompositeOperationDestinationIn] = {GL_ZERO, GL_SRC_ALPHA, 1},
+    [kEJCompositeOperationSourceIn] = {GL_DST_ALPHA, GL_ZERO, 1},
+    [kEJCompositeOperationSourceOut] = {GL_ONE_MINUS_DST_ALPHA,GL_ZERO,1},
+    [kEJCompositeOperationDestinationAtop] = {GL_ONE_MINUS_DST_ALPHA, GL_SRC_ALPHA, 1},
+    [kEJCompositeOperationCopy] = {GL_ONE,GL_ZERO,1}
 };
 
 


### PR DESCRIPTION
Ejecta misses some globalCompositeOperation : 'destination-in', 'destination-atop', 'source-in', 'source-out', 'copy'.

This pull request tries to add these composites. the core code follows : 

```
    [kEJCompositeOperationDestinationIn] = {GL_ZERO, GL_SRC_ALPHA, 1},
    [kEJCompositeOperationSourceIn] = {GL_DST_ALPHA, GL_ZERO, 1},
    [kEJCompositeOperationSourceOut] = {GL_ONE_MINUS_DST_ALPHA,GL_ZERO,1},
    [kEJCompositeOperationDestinationAtop] = {GL_ONE_MINUS_DST_ALPHA, GL_SRC_ALPHA, 1},
    [kEJCompositeOperationCopy] = {GL_ONE,GL_ZERO,1}
```
