### PR TITLE
* Data URI support for image source.

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingImage.m
+++ b/Source/Ejecta/EJCanvas/EJBindingImage.m
@@ -1,6 +1,7 @@
 #import "EJBindingImage.h"
 #import "EJJavaScriptView.h"
 #import "EJNonRetainingProxy.h"
+#import "EJTexture.h"
 
 @implementation EJBindingImage
 @synthesize texture;
@@ -14,8 +15,16 @@
 	// may be the only thing holding on to it
 	JSValueProtect(scriptView.jsGlobalContext, jsObject);
 	
-	NSLog(@"Loading Image: %@", path);
-	NSString *fullPath = [scriptView pathForResource:path];
+	NSString *fullPath;
+
+	// If path is a Data URI we don't want to prepend resource paths
+	if ( [EJTexture isDataURI:path] ) {
+		NSLog(@"Loading Image from Data URI");
+		fullPath = [NSString stringWithString:path];
+	} else {
+		NSLog(@"Loading Image: %@", path);
+		fullPath = [scriptView pathForResource:path];
+	}
 	
 	// Use a non-retaining proxy for the callback operation and take care that the
 	// loadCallback is always cancelled when dealloc'ing

--- a/Source/Ejecta/EJCanvas/EJTexture.h
+++ b/Source/Ejecta/EJCanvas/EJTexture.h
@@ -45,6 +45,7 @@ typedef enum {
 - (void)updateWithPixels:(NSData *)pixels atX:(int)x y:(int)y width:(int)subWidth height:(int)subHeight;
 
 - (NSMutableData *)loadPixelsFromPath:(NSString *)path;
+- (NSMutableData *)loadPixelsFromUIImage:(UIImage *)image;
 
 - (GLint)getParam:(GLenum)pname;
 - (void)setParam:(GLenum)pname param:(GLenum)param;
@@ -58,6 +59,8 @@ typedef enum {
 + (void)premultiplyPixels:(const GLubyte *)inPixels to:(GLubyte *)outPixels byteLength:(int)byteLength format:(GLenum)format;
 + (void)unPremultiplyPixels:(const GLubyte *)inPixels to:(GLubyte *)outPixels byteLength:(int)byteLength format:(GLenum)format;
 + (void)flipPixelsY:(GLubyte *)pixels bytesPerRow:(int)bytesPerRow rows:(int)rows;
+
++ (BOOL)isDataURI:(NSString *) path;
 
 @property (readwrite, nonatomic) BOOL drawFlippedY;
 @property (readonly, nonatomic) BOOL isDynamic;


### PR DESCRIPTION
Hi!

I was in need of Data URI support for images src so I've implemented it.
I think this is very handy and allows Ejecta to be even closer to HTML5 specifications.

I am not very familiar with Obj-C so please let me know if there is anything I did wrong or that I can do better.

Here are the things I changed:
1. In EJTexture: moved outside of _**loadPixelsFromPath**_ the code to load pixels from an UIImage, into a new method called _**loadPixelsFromUIImage**_.
2. In EJTexture: added a static method to identify if a path (basically what the user set in image's .src) is really a file path or is a Data URI string. Method named _**isDataURI**_.
3. Using this method in EJBindingImage to avoid prepending the device "path to resource" if this path is in fact not a file, but a Data URI string.
4. In EJTexture's _**cachedTextureWithPath**_: if the path is in fact a Data URI string, we don't want to use the string itself as cache key because this string may be super huge. In this case, using instead it's sha1 hash. Added for this purpose a static inline _**NSStringCCHashFunction**_ from https://github.com/hypercrypt/NSString-Hashes/blob/master/NSString%2BHashes.m (public domain license) because the default Obj-C string hash value seems to be very bad and to have more collisions issues than any other hashing algorithm.
5. Finally, in _**loadPixelsFromPath**_: if the path is a Data URI we create the UIImage from this data (simple 3 liner) else the UIImage is created the same way as before. And then obviously, calls the _**loadPixelsFromUIImage**_ method (cf point 1).

Here is a very small example to test it out:

```
var w = window.innerWidth;
var h = window.innerHeight;
var canvas = document.getElementById('canvas');
canvas.width = w;
canvas.height = h;
var ctx = canvas.getContext('2d');

// Small red dot image. For a better example, use an online service to generate Data URI from a picture.
// (for example Google first answer with "picture to data uri" search)
var imageData = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';

var img = new Image();
img.onload = function() {
    console.log('Image loaded. Size is ' + this.width + ' x ' + this.height);
    ctx.fillStyle = '#000000';
    ctx.fillRect(0, 0, w, h);
    ctx.drawImage(this, 0, 0);
};

img.src = imageData;
```

Thank you in advance for having a look to this PR!
If we everything is going well with it, I will next PR an EJBindingImagePicker I did to pick pictures from the photo roll :smile:.

ps: I just noticed there was another PR opened for the same feature: #241.
It would be great if you could merge one or the other!! :smile:
