### PR TITLE
set default value of  document.hidden

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -159,6 +159,7 @@ window.document = {
 	documentElement: window,
 	location: { href: 'index' },
 	visibilityState: 'visible',
+	hidden: false,
 	
 	head: new HTMLElement( 'head' ),
 	body: new HTMLElement( 'body' ),


### PR DESCRIPTION
I think document.hidden need default value "false".

Because  sometimes I need to check it's value by "===" in a function and the function will be called as soon as the app start-up.
