### PR TITLE
Add an error log message about path

### DIFF
--- a/Source/Ejecta/EJJavaScriptView.m
+++ b/Source/Ejecta/EJJavaScriptView.m
@@ -212,7 +212,7 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 
 - (JSValueRef)evaluateScript:(NSString *)script sourceURL:(NSString *)sourceURL {
 	if( !script || script.length == 0 ) {
-		NSLog(@"Error: No or empty script given");
+		NSLog(@"Error: No or empty script given. Path is %@",sourceURL);
 		return NULL;
 	}
     


### PR DESCRIPTION
Sometimes, a game needs include many js-files.
But the error log only tells developers "Error: No or empty script given", it can not help developers which js is wrong.

So I think Ejecta needs to add a message about path
