### PR TITLE
Add support for HTTP/HTTPS URIs for images

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingImage.m
+++ b/Source/Ejecta/EJCanvas/EJBindingImage.m
@@ -18,8 +18,9 @@
 	NSString *fullPath;
 
 	// If path is a Data URI we don't want to prepend resource paths
-	if( [path hasPrefix:@"data:"] ) {
-		NSLog(@"Loading Image from Data URI");
+	if( [path hasPrefix:@"data:"] || 
+			[path hasPrefix:@"http:"] || [path hasPrefix:@"https:"]) {
+		NSLog(@"Loading Image from URI");
 		fullPath = path;
 	}
 	else {

--- a/Source/Ejecta/EJCanvas/EJTexture.m
+++ b/Source/Ejecta/EJCanvas/EJTexture.m
@@ -380,10 +380,11 @@ typedef struct {
 }
 
 - (NSMutableData *)loadPixelsFromPath:(NSString *)path {
-	BOOL isDataURI = [path hasPrefix:@"data:"];
+	BOOL isURI = [path hasPrefix:@"data:"] ||
+		[path hasPrefix:@"http:"] || [path hasPrefix:@"https:"];
 	
 	// Try @2x texture?
-	if( !isDataURI && [UIScreen mainScreen].scale == 2 ) {
+	if( !isURI && [UIScreen mainScreen].scale == 2 ) {
 		NSString *path2x = [[[path stringByDeletingPathExtension]
 			stringByAppendingString:@"@2x"]
 			stringByAppendingPathExtension:[path pathExtension]];
@@ -396,13 +397,13 @@ typedef struct {
 	
 	
 	NSMutableData *pixels;
-	if( isDataURI ) {
+	if( isURI ) {
 		// Load directly from a Data URI string
 		UIImage *tmpImage = [[UIImage alloc] initWithData:
 			[NSData dataWithContentsOfURL:[NSURL URLWithString:path]]];
 		
 		if( !tmpImage ) {
-			NSLog(@"Error Loading image from Data URI.");
+			NSLog(@"Error Loading image from URI.");
 			return NULL;
 		}
 		pixels = [self loadPixelsFromUIImage:tmpImage];


### PR DESCRIPTION
Support is already in place for data URIs using dataWithContentsOfURL. 
Expand to include HTTP/HTTPS URIs too.

This will cover issue #303 
