### PR TITLE
Virtual DOM elements now support .nodeName property 

### DIFF
--- a/Source/Ejecta/EJAudio/EJBindingAudio.m
+++ b/Source/Ejecta/EJAudio/EJBindingAudio.m
@@ -252,4 +252,8 @@ EJ_BIND_EVENT(loadedmetadata);
 EJ_BIND_EVENT(canplaythrough);
 EJ_BIND_EVENT(ended);
 
+EJ_BIND_GET(nodeName, ctx ) {
+	return NSStringToJSValue(ctx, @"AUDIO");
+}
+
 @end

--- a/Source/Ejecta/EJBindingVideo.m
+++ b/Source/Ejecta/EJBindingVideo.m
@@ -200,4 +200,8 @@ EJ_BIND_EVENT(loadedmetadata);
 EJ_BIND_EVENT(ended);
 EJ_BIND_EVENT(click);
 
+EJ_BIND_GET(nodeName, ctx ) {
+	return NSStringToJSValue(ctx, @"VIDEO");
+}
+
 @end

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -339,4 +339,8 @@ EJ_BIND_FUNCTION(toDataURLHD, ctx, argc, argv) {
 	return [self toDataURLWithCtx:ctx argc:argc argv:argv hd:YES];
 }
 
+EJ_BIND_GET(nodeName, ctx ) {
+	return NSStringToJSValue(ctx, @"CANVAS");
+}
+
 @end

--- a/Source/Ejecta/EJCanvas/EJBindingImage.m
+++ b/Source/Ejecta/EJCanvas/EJBindingImage.m
@@ -109,5 +109,8 @@ EJ_BIND_GET(complete, ctx ) {
 EJ_BIND_EVENT(load);
 EJ_BIND_EVENT(error);
 
+EJ_BIND_GET(nodeName, ctx ) {
+	return NSStringToJSValue(ctx, @"IMG");
+}
 
 @end


### PR DESCRIPTION
cf. http://quirksmode.org/dom/core/#t20

The following code is now working (may be useful to identify what a variable is):

``` javascript
var v;

v = document.createElement('canvas');
console.log('v is a canvas: ' + (v.nodeName === 'CANVAS'));

v = new Image();
console.log('v is an image: ' + (v.nodeName === 'IMG'));

v = document.createElement('video');
console.log('v is a video element: ' + (v.nodeName === 'VIDEO'));

v = document.createElement('audio');
console.log('v is an audio element: ' + (v.nodeName === 'AUDIO'));
```
