### PR TITLE
iCloud Key Value Storage

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingImage.m
+++ b/Source/Ejecta/EJCanvas/EJBindingImage.m
@@ -109,5 +109,15 @@ EJ_BIND_GET(complete, ctx ) {
 EJ_BIND_EVENT(load);
 EJ_BIND_EVENT(error);
 
+EJ_BIND_FUNCTION(unload, ctx, argc, argv){
+    
+    [texture release];
+    texture = nil;
+    [path release];
+    path = nil;
+    return NULL;
+}
+
+
 
 @end

--- a/Source/Ejecta/EJUtils/EJBindingLocalStorage.m
+++ b/Source/Ejecta/EJUtils/EJBindingLocalStorage.m
@@ -1,13 +1,26 @@
 #import "EJBindingLocalStorage.h"
 
 
-@implementation EJBindingLocalStorage
+
+@implementation EJBindingLocalStorage{
+    BOOL useiCloud;
+    JSObjectRef callback;
+}
+
+
 
 EJ_BIND_FUNCTION(getItem, ctx, argc, argv ) {
 	if( argc < 1 ) return NULL;
 	
 	NSString *key = JSValueToNSString( ctx, argv[0] );
-	NSString *value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
+    NSString *value;
+    
+    if(!useiCloud)
+        value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
+    else
+        value = [[NSUbiquitousKeyValueStore defaultStore] objectForKey:key];
+    
+    
 	return value ? NSStringToJSValue( ctx, value ) : JSValueMakeNull(ctx);
 }
 
@@ -18,8 +31,15 @@ EJ_BIND_FUNCTION(setItem, ctx, argc, argv ) {
 	NSString *value = JSValueToNSString( ctx, argv[1] );
 	
 	if( !key || !value ) return NULL;
-	[[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
-	[[NSUserDefaults standardUserDefaults] synchronize];
+    if(!useiCloud)
+    {
+        [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }else{
+        [[NSUbiquitousKeyValueStore defaultStore] setObject:value forKey:key];
+        [[NSUbiquitousKeyValueStore defaultStore] synchronize];
+    }
+    
 	
 	return NULL;
 }
@@ -28,14 +48,85 @@ EJ_BIND_FUNCTION(removeItem, ctx, argc, argv ) {
 	if( argc < 1 ) return NULL;
 	
 	NSString *key = JSValueToNSString( ctx, argv[0] );
-	[[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+    
+    if(!useiCloud)
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+    else
+        [[NSUbiquitousKeyValueStore defaultStore] removeObjectForKey:key];
 	
 	return NULL;
 }
 
 EJ_BIND_FUNCTION(clear, ctx, argc, argv ) {
 	[[NSUserDefaults standardUserDefaults] setPersistentDomain:@{} forName:[[NSBundle mainBundle] bundleIdentifier]];
+    NSDictionary *allValues = [[NSUbiquitousKeyValueStore defaultStore] dictionaryRepresentation];
+    
+    [allValues enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        [[NSUbiquitousKeyValueStore defaultStore] removeObjectForKey:key];
+    }];
+    
+    
 	return NULL;
+}
+
+EJ_BIND_FUNCTION(useiCloud, ctx, argc, argv){
+    
+    
+    if(
+       argc < 1 ||
+       !JSValueIsObject(ctx, argv[0])
+       ) {
+        return NULL;
+    }
+    
+    callback = JSValueToObject(ctx, argv[0], NULL);
+    JSValueProtect(ctx, callback);
+    
+    useiCloud = YES;
+    
+
+    NSLog(@"iCloud access ");
+    return JSValueMakeBoolean(ctx, YES);
+    
+    NSUbiquitousKeyValueStore *store = [NSUbiquitousKeyValueStore defaultStore];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(storeDidChange:)
+                                                 name:NSUbiquitousKeyValueStoreDidChangeExternallyNotification
+                                               object:store];
+    
+    [[NSUbiquitousKeyValueStore defaultStore] synchronize];      
+        
+    
+}
+
+
+#pragma mark - Observer
+
+- (void)storeDidChange:(NSNotification *)notification
+{
+    if( !callback ) {
+        NSLog(@"iCloud Error: No Callback");
+        return;
+    }
+    
+    NSLog(@"iCloud Callback Set");
+    
+    NSDictionary* userInfo = [notification userInfo];
+    
+    NSArray* changedKeys =  [userInfo objectForKey:NSUbiquitousKeyValueStoreChangedKeysKey];
+    JSGlobalContextRef ctx = scriptView.jsGlobalContext;
+    
+    for (NSString* key in changedKeys) {
+        
+        NSString *object = [[NSUbiquitousKeyValueStore defaultStore] objectForKey:key];
+        
+        JSValueRef params[] = {NSStringToJSValue( ctx, key ),NSStringToJSValue( ctx, object )};
+        [scriptView invokeCallback:callback thisObject:jsObject argc:2 argv:params];
+       
+    }
+    
+    
+
 }
 
 


### PR DESCRIPTION
Added iCloud Key Value Storage Functionality

You need to call 
```
localStorage.useiCloud(function(key,value)
		{
			
		});
```

to set the callback function to update for changes from iCloud and tell Ejecta to use iCloud storage instead of NSUserDefaults

This pull request does not contain the entitlement changes etc. you need to make to the xcode project itself

