### PR TITLE
Shader management

### DIFF
--- a/Ejecta.xcodeproj/project.pbxproj
+++ b/Ejecta.xcodeproj/project.pbxproj
@@ -113,6 +113,10 @@
 		B6F629D116F353C800F16BAC /* EJBindingCanvasStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F629D016F353C700F16BAC /* EJBindingCanvasStyle.m */; };
 		B6F9AFC0169F81D400ABD91A /* EJBindingWindowEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F9AFBF169F81D400ABD91A /* EJBindingWindowEvents.m */; };
 		B870BDE916F2E11A00827F01 /* EJBindingWebGLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B870BDE816F2E11A00827F01 /* EJBindingWebGLExtensions.m */; };
+		C6374A20189F3D87003113BD /* EJBindingMaterial.m in Sources */ = {isa = PBXBuildFile; fileRef = C6374A1F189F3D87003113BD /* EJBindingMaterial.m */; };
+		C6374A24189F7476003113BD /* EJGLProgram2DTint.m in Sources */ = {isa = PBXBuildFile; fileRef = C6374A23189F7476003113BD /* EJGLProgram2DTint.m */; };
+		C6374A25189F89CC003113BD /* Tint.fsh in Resources */ = {isa = PBXBuildFile; fileRef = C6481289187E8970001BF7B9 /* Tint.fsh */; };
+		C648128A187E8970001BF7B9 /* Tint.fsh in Sources */ = {isa = PBXBuildFile; fileRef = C6481289187E8970001BF7B9 /* Tint.fsh */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -307,6 +311,11 @@
 		B6F9AFBF169F81D400ABD91A /* EJBindingWindowEvents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJBindingWindowEvents.m; sourceTree = "<group>"; };
 		B870BDE716F2E10400827F01 /* EJBindingWebGLExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EJBindingWebGLExtensions.h; path = WebGL/EJBindingWebGLExtensions.h; sourceTree = "<group>"; };
 		B870BDE816F2E11A00827F01 /* EJBindingWebGLExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EJBindingWebGLExtensions.m; path = WebGL/EJBindingWebGLExtensions.m; sourceTree = "<group>"; };
+		C6374A1E189F3D87003113BD /* EJBindingMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJBindingMaterial.h; sourceTree = "<group>"; };
+		C6374A1F189F3D87003113BD /* EJBindingMaterial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJBindingMaterial.m; sourceTree = "<group>"; };
+		C6374A22189F7476003113BD /* EJGLProgram2DTint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJGLProgram2DTint.h; sourceTree = "<group>"; };
+		C6374A23189F7476003113BD /* EJGLProgram2DTint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJGLProgram2DTint.m; sourceTree = "<group>"; };
+		C6481289187E8970001BF7B9 /* Tint.fsh */ = {isa = PBXFileReference; explicitFileType = sourcecode.glsl; fileEncoding = 4; path = Tint.fsh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -393,6 +402,7 @@
 		B609F2CB16AD873900A3B2B9 /* Shaders */ = {
 			isa = PBXGroup;
 			children = (
+				C6481289187E8970001BF7B9 /* Tint.fsh */,
 				B64C878016B800C10097CD5B /* AlphaTexture.fsh */,
 				B64C878116B800C10097CD5B /* Flat.fsh */,
 				B64C878216B800C10097CD5B /* Pattern.fsh */,
@@ -607,6 +617,8 @@
 				B6F114F11676BD40001F1324 /* EJCanvasContext2DScreen.m */,
 				B6F114F21676BD40001F1324 /* EJCanvasContext2DTexture.h */,
 				B6F114F31676BD40001F1324 /* EJCanvasContext2DTexture.m */,
+				C6374A1E189F3D87003113BD /* EJBindingMaterial.h */,
+				C6374A1F189F3D87003113BD /* EJBindingMaterial.m */,
 				B664B9891699F3370093E04E /* EJBindingCanvasPattern.h */,
 				B664B98A1699F3380093E04E /* EJBindingCanvasPattern.m */,
 				B664B98C1699F49B0093E04E /* EJCanvasPattern.h */,
@@ -634,6 +646,8 @@
 				B64C87A816B80F410097CD5B /* EJGLProgram2D.m */,
 				B64C87A916B80F450097CD5B /* EJGLProgram2DRadialGradient.h */,
 				B64C87AA16B80F4C0097CD5B /* EJGLProgram2DRadialGradient.m */,
+				C6374A22189F7476003113BD /* EJGLProgram2DTint.h */,
+				C6374A23189F7476003113BD /* EJGLProgram2DTint.m */,
 			);
 			path = 2D;
 			sourceTree = "<group>";
@@ -716,6 +730,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6374A25189F89CC003113BD /* Tint.fsh in Resources */,
 				B64C878A16B800DA0097CD5B /* AlphaTexture.fsh in Resources */,
 				B64C878B16B800DA0097CD5B /* Flat.fsh in Resources */,
 				B64C878C16B800DA0097CD5B /* Pattern.fsh in Resources */,
@@ -755,6 +770,7 @@
 				B64CE667166682700087CF94 /* EJSharedOpenALManager.m in Sources */,
 				B64CE668166682700087CF94 /* EJBindingBase.m in Sources */,
 				B64CE669166682700087CF94 /* EJBindingEjectaCore.m in Sources */,
+				C6374A24189F7476003113BD /* EJGLProgram2DTint.m in Sources */,
 				B64CE66A166682700087CF94 /* EJBindingEventedBase.m in Sources */,
 				B64CE66B166682700087CF94 /* EAGLView.m in Sources */,
 				B64CE66D166682700087CF94 /* EJBindingImage.m in Sources */,
@@ -766,6 +782,7 @@
 				B64CE67C166682700087CF94 /* EJBindingHttpRequest.m in Sources */,
 				B64CE67D166682700087CF94 /* EJBindingLocalStorage.m in Sources */,
 				B64CE67E166682700087CF94 /* EJBindingTouchInput.m in Sources */,
+				C648128A187E8970001BF7B9 /* Tint.fsh in Sources */,
 				B64CE67F166682700087CF94 /* AppDelegate.m in Sources */,
 				B64CE682166682700087CF94 /* main.m in Sources */,
 				B6F9AFC0169F81D400ABD91A /* EJBindingWindowEvents.m in Sources */,
@@ -796,6 +813,7 @@
 				B668FCEE1821C08500D4F629 /* EJFontCache.m in Sources */,
 				3EF00C5916C29360004599A4 /* EJJavaScriptView.m in Sources */,
 				B630048C16CB098D0036D8D4 /* EJClassLoader.m in Sources */,
+				C6374A20189F3D87003113BD /* EJBindingMaterial.m in Sources */,
 				B699669816CC4E6E006B9456 /* EJTextureStorage.m in Sources */,
 				B699669B16CC55F5006B9456 /* EJSharedTextureCache.m in Sources */,
 				B699669E16CC579E006B9456 /* EJSharedOpenGLContext.m in Sources */,
@@ -821,6 +839,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -836,6 +855,7 @@
 				);
 				OTHER_CFLAGS = "-DDEBUG";
 				PRODUCT_NAME = Ejecta;
+				PROVISIONING_PROFILE = "3F3F2556-A34A-4417-9F0B-6850AE20005E";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -845,6 +865,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Source/Prefix.pch;
@@ -856,6 +877,7 @@
 					"\"$(SRCROOT)/Source/lib\"",
 				);
 				PRODUCT_NAME = Ejecta;
+				PROVISIONING_PROFILE = "3F3F2556-A34A-4417-9F0B-6850AE20005E";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -866,7 +888,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = armv7;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PREPROCESSOR_DEFINITIONS = NS_BLOCK_ASSERTIONS;
@@ -880,7 +902,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DDEBUG";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "3F3F2556-A34A-4417-9F0B-6850AE20005E";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = armv7;
 			};
@@ -890,7 +912,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = armv7;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -902,7 +924,7 @@
 				INFOPLIST_FILE = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "3F3F2556-A34A-4417-9F0B-6850AE20005E";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = armv7;

--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.h
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.h
@@ -5,6 +5,7 @@
 @interface EJBindingCanvasContext2D : EJBindingBase {
 	JSObjectRef jsCanvas;
 	EJCanvasContext2D *renderingContext;
+	JSStringRef materialName;
 }
 
 - (id)initWithCanvas:(JSObjectRef)canvas renderingContext:(EJCanvasContext2D *)renderingContextp;

--- a/Source/Ejecta/EJCanvas/2D/EJBindingMaterial.h
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingMaterial.h
@@ -1,0 +1,26 @@
+#import "EJBindingBase.h"
+#import "EJGLProgram2D.h"
+
+typedef struct {
+	void (*glUniformFunction)(GLint, GLsizei, const void *);
+	int count;
+	void *values;
+	GLint location;
+} EJUniform;
+
+@interface EJBindingMaterial : EJBindingBase {
+	// TODO: Should it wrap a Material object?
+	EJGLProgram2D *program;
+	NSString *shaderName;
+	BOOL hasChanged;
+	int uniformsCount;
+	EJUniform *uniforms;
+}
+
+@property (readonly, nonatomic) EJGLProgram2D *program;
+@property (nonatomic, retain) NSString *shaderName;
+@property (nonatomic) BOOL hasChanged;
+@property (readonly, nonatomic) int uniformsCount;
+@property (readonly, nonatomic) EJUniform *uniforms;
+
+@end

--- a/Source/Ejecta/EJCanvas/2D/EJBindingMaterial.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingMaterial.m
@@ -1,0 +1,204 @@
+#import "EJBindingMaterial.h"
+
+#import "EJConvertWebGL.h"
+
+@implementation EJBindingMaterial
+@synthesize program;
+@synthesize hasChanged;
+@synthesize uniformsCount;
+@synthesize uniforms;
+
+- (void)createWithJSObject:(JSObjectRef)obj scriptView:(EJJavaScriptView *)view {
+	[super createWithJSObject:obj scriptView:view];
+	hasChanged = false;
+	uniformsCount = 0;
+	uniforms = NULL;
+}
+
+- (void)dealloc {
+	[shaderName release];
+	shaderName = nil;
+	// Remove the uniforms allocated manually
+	[self freeUniforms];
+	
+	[super dealloc];
+}
+
+- (void)assignProgramWithName:(NSString *)name {
+	// Check first if a shader program with the specified name exists
+	EJSharedOpenGLContext *sharedGLContext = scriptView.openGLContext;
+	NSString *propertySuffix = @"glProgram2D";
+	NSString *selectorName = [propertySuffix stringByAppendingString:name];
+	SEL programSelector = NSSelectorFromString(selectorName);
+	
+	if ([sharedGLContext respondsToSelector:programSelector]) {
+		program = [sharedGLContext performSelector:programSelector];
+		if (program) {
+			if (shaderName) {
+				[shaderName release];
+			}
+			shaderName = [name retain];
+			
+            [self freeUniforms];
+			uniformsCount = program.additionalUniforms.count;
+			uniforms = (EJUniform *)malloc(uniformsCount * sizeof(EJUniform));
+			int i = 0;
+			for (NSString *key in program.additionalUniforms) {
+				NSValue *locationValue = [program.additionalUniforms objectForKey:key];
+				GLint *location;
+				[locationValue getValue:&location];
+				uniforms[i].glUniformFunction = NULL;
+				uniforms[i].count = 0;
+				uniforms[i].values = NULL;
+				uniforms[i].location = *location;
+				++i;
+			}
+		}
+	} else {
+		return;
+	}
+}
+
+- (void)freeUniforms {
+	if (uniforms != NULL) {
+		for (int i = 0; i < uniformsCount; ++i) {
+			free(uniforms[i].values);
+		}
+		free(uniforms);
+		uniforms = NULL;
+		uniformsCount = 0;
+	}
+}
+
+EJ_BIND_GET(shader, ctx) {
+	JSStringRef shader = JSStringCreateWithUTF8CString([shaderName UTF8String]);
+	JSValueRef ret = JSValueMakeString(ctx, shader);
+	JSStringRelease(shader);
+	return ret;
+}
+
+EJ_BIND_SET(shader, ctx, value) {
+	NSString *newShaderName = JSValueToNSString(ctx, value);
+	
+	// Same as the old shader name? Nothing to do here
+	if ([shaderName isEqualToString:newShaderName]) {
+		return;
+	}
+	
+    hasChanged = true;
+	
+	// Release the old shader name and the program?
+	if (shaderName) {
+		[shaderName release];
+		shaderName = nil;
+	}
+	[self freeUniforms];
+	
+	program = nil;
+	
+	if (!JSValueIsNull(ctx, value) && [newShaderName length]) {
+		[self assignProgramWithName:newShaderName];
+	}
+}
+
+// TODO: Support Matrix uniforms too
+EJ_BIND_FUNCTION(setUniform, ctx, argc, argv) {
+	if (argc < 2) {
+		return NULL;
+	}
+	
+	if (JSValueIsNull(ctx, argv[0]) || JSValueIsNull(ctx, argv[1])) {
+		return NULL;
+	}
+	
+	NSString *uniform = JSValueToNSString(ctx, argv[0]);
+	NSString *uniformType = JSValueToNSString(ctx, argv[1]);
+	
+	if ([uniform length] && [uniformType length])  {
+		NSValue *locationValue = [program.additionalUniforms objectForKey:uniform];
+		if (locationValue) {
+			EJUniform *newUniform = NULL;
+			GLint *location;
+
+			[locationValue getValue:&location];
+			for (int i = 0; i < uniformsCount; ++i) {
+				if (uniforms[i].location == *location) {
+					newUniform = &uniforms[i];
+					break;
+				}
+			}
+			if (newUniform != NULL) {
+				GLsizei count = 0;
+				void *values;
+				size_t uniformArraySize;
+				
+				// Check if the uniform type is recognized
+				// TODO: Capture error?
+				NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"gluniform([1234][f|i])v?"
+                                                                                       options:NSRegularExpressionCaseInsensitive
+                                                                                         error:nil];
+				NSUInteger numberMatches = [regex numberOfMatchesInString:uniformType
+                                                                  options:0
+																	range:NSMakeRange(0, [uniformType length])];
+				if (numberMatches == 1) {
+					// Extract the uniform type
+					NSString *componentType = [regex stringByReplacingMatchesInString:uniformType
+                                                                              options:0
+																				range:NSMakeRange(0, [uniformType length])
+                                                                         withTemplate:@"$1"];
+
+					if ([componentType hasSuffix:@"f"]) {
+						values = JSValueToGLfloatArray(ctx, argv[2], 1, &count);
+						uniformArraySize = count * sizeof(GLfloat);
+					} else if ([uniformType hasSuffix:@"i"]) {
+						values = JSValueToGLintArray(ctx, argv[2], 1, &count);
+						uniformArraySize = count * sizeof(GLint);
+					}
+					               
+					if (count > 0) {
+						void *uniformValues = malloc(uniformArraySize);;
+						memcpy(uniformValues, values, uniformArraySize);
+						if (newUniform->values != NULL) {
+							free(newUniform->values);
+						}
+						newUniform->values = uniformValues;
+						
+						if ([componentType isEqualToString:@"1f"]) {
+							newUniform->count = count;
+							newUniform->glUniformFunction = glUniform1fv;
+						} else if ([componentType isEqualToString:@"2f"]) {
+							newUniform->count = floor((float)count/2);
+							newUniform->glUniformFunction = glUniform2fv;
+						} else if ([componentType isEqualToString:@"3f"]) {
+							newUniform->count = floor((float)count/3);
+							newUniform->glUniformFunction = glUniform3fv;
+						} else if ([componentType isEqualToString:@"4f"]) {
+							newUniform->count = floor((float)count/4);
+							newUniform->glUniformFunction = glUniform4fv;
+						} else if ([componentType isEqualToString:@"1i"]) {
+							newUniform->count = count;
+							newUniform->glUniformFunction = glUniform1iv;
+						} else if ([componentType isEqualToString:@"2i"]) {
+							newUniform->count = floor((float)count/2);
+							newUniform->glUniformFunction = glUniform2iv;
+						} else if ([componentType isEqualToString:@"3i"]) {
+							newUniform->count = floor((float)count/3);
+							newUniform->glUniformFunction = glUniform3iv;
+						} else if ([componentType isEqualToString:@"4i"]) {
+							newUniform->count = floor((float)count/4);
+							newUniform->glUniformFunction = glUniform4iv;
+						}
+						
+						hasChanged = true;
+					}
+				} else {
+					NSLog(@"Warning: Uniform type not recognized. Matrix uniforms and unsigned int types are not currently supported.");
+				}
+			}
+		}
+	}
+	
+	return NULL;
+}
+
+@end

--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
@@ -7,6 +7,7 @@
 #import "EJFont.h"
 #import "EJFontCache.h"
 #import "EJSharedOpenGLContext.h"
+#import "EJBindingMaterial.h"
 
 #define EJ_CANVAS_STATE_STACK_SIZE 16
 
@@ -132,6 +133,7 @@ static inline EJColorRGBA EJCanvasBlendStrokeColor( EJCanvasState *state ) {
 	
 	EJJavaScriptView *scriptView;
 	EJGLProgram2D *currentProgram;
+	EJBindingMaterial *currentMaterial;
 	EJSharedOpenGLContext *sharedGLContext;
 }
 
@@ -143,6 +145,7 @@ static inline EJColorRGBA EJCanvasBlendStrokeColor( EJCanvasState *state ) {
 - (void)bindVertexBuffer;
 - (void)prepare;
 - (void)setTexture:(EJTexture *)newTexture;
+- (void)setMaterial:(EJBindingMaterial *)newMaterial;
 - (void)setProgram:(EJGLProgram2D *)program;
 - (void)pushTriX1:(float)x1 y1:(float)y1 x2:(float)x2 y2:(float)y2
 	x3:(float)x3 y3:(float)y3
@@ -179,7 +182,7 @@ static inline EJColorRGBA EJCanvasBlendStrokeColor( EJCanvasState *state ) {
 - (void)scaleX:(float)x y:(float)y;
 - (void)transformM11:(float)m11 m12:(float)m12 m21:(float)m21 m22:(float)m2 dx:(float)dx dy:(float)dy;
 - (void)setTransformM11:(float)m11 m12:(float)m12 m21:(float)m21 m22:(float)m2 dx:(float)dx dy:(float)dy;
-- (void)drawImage:(EJTexture *)image sx:(float)sx sy:(float)sy sw:(float)sw sh:(float)sh dx:(float)dx dy:(float)dy dw:(float)dw dh:(float)dh;
+- (void)drawImage:(EJTexture *)image sx:(float)sx sy:(float)sy sw:(float)sw sh:(float)sh dx:(float)dx dy:(float)dy dw:(float)dw dh:(float)dh material:(EJBindingMaterial *)material;
 - (void)fillRectX:(float)x y:(float)y w:(float)w h:(float)h;
 - (void)strokeRectX:(float)x y:(float)y w:(float)w h:(float)h;
 - (void)clearRectX:(float)x y:(float)y w:(float)w h:(float)h;

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2D.h
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2D.h
@@ -13,6 +13,7 @@ enum {
 @interface EJGLProgram2D : NSObject {
 	GLuint program;
 	GLuint screen;
+	NSDictionary *additionalUniforms;
 }
 
 - (id)initWithVertexShader:(NSString *)vertexShaderFile fragmentShader:(NSString *)fragmentShaderFile;
@@ -27,5 +28,7 @@ enum {
 
 @property (nonatomic, readonly) GLuint screen;
 @property (nonatomic, readonly) GLuint translate;
+
+@property (nonatomic, retain) NSDictionary *additionalUniforms;
 
 @end

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2D.m
@@ -5,6 +5,8 @@
 @synthesize program;
 @synthesize screen;
 
+@synthesize additionalUniforms;
+
 - (id)initWithVertexShader:(NSString *)vertexShaderFile fragmentShader:(NSString *)fragmentShaderFile {
 	if( self = [super init] ) {
 		program = glCreateProgram();
@@ -31,6 +33,8 @@
 
 - (void)dealloc {
 	if( program ) { glDeleteProgram(program); }
+	[additionalUniforms release];
+	additionalUniforms = nil;
 	[super dealloc];
 }
 

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2DRadialGradient.h
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2DRadialGradient.h
@@ -1,10 +1,8 @@
 #import "EJGLProgram2D.h"
 
 @interface EJGLProgram2DRadialGradient : EJGLProgram2D {
-	GLuint inner, diff;
+	GLint inner;
+	GLint diff;
 }
-
-@property (nonatomic, readonly) GLuint inner;
-@property (nonatomic, readonly) GLuint diff;
 
 @end

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2DRadialGradient.m
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2DRadialGradient.m
@@ -1,13 +1,17 @@
 #import "EJGLProgram2DRadialGradient.h"
 
 @implementation EJGLProgram2DRadialGradient
-@synthesize inner, diff;
 
 - (void)getUniforms {
 	[super getUniforms];
 	
 	inner = glGetUniformLocation(program, "inner");
 	diff = glGetUniformLocation(program, "diff");
+	if(!self.additionalUniforms) {
+		self.additionalUniforms = [NSDictionary dictionaryWithObjectsAndKeys:
+									[NSValue valueWithPointer:&inner], @"inner",
+									[NSValue valueWithPointer:&diff], @"diff", nil];
+    }
 }
 
 @end

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2DTint.h
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2DTint.h
@@ -1,0 +1,8 @@
+#import "EJGLProgram2D.h"
+
+@interface EJGLProgram2DTint : EJGLProgram2D {
+	GLint tintAdd;
+	GLint tintMul;
+}
+
+@end

--- a/Source/Ejecta/EJCanvas/2D/EJGLProgram2DTint.m
+++ b/Source/Ejecta/EJCanvas/2D/EJGLProgram2DTint.m
@@ -1,0 +1,17 @@
+#import "EJGLProgram2DTint.h"
+
+@implementation EJGLProgram2DTint
+
+- (void)getUniforms {
+	[super getUniforms];
+	
+    tintAdd = glGetUniformLocation(program, "tintAdd");
+    tintMul = glGetUniformLocation(program, "tintMul");
+    if(!self.additionalUniforms) {
+        self.additionalUniforms = [NSDictionary dictionaryWithObjectsAndKeys:
+                                   [NSValue valueWithPointer:&tintAdd], @"tintAdd",
+                                   [NSValue valueWithPointer:&tintMul], @"tintMul", nil];
+    }
+}
+
+@end

--- a/Source/Ejecta/EJCanvas/2D/Shaders/Tint.fsh
+++ b/Source/Ejecta/EJCanvas/2D/Shaders/Tint.fsh
@@ -1,0 +1,10 @@
+varying lowp vec4 vColor;
+varying highp vec2 vUv;
+
+uniform sampler2D texture;
+uniform mediump vec4 tintAdd;
+uniform mediump vec4 tintMul;
+
+void main() {
+    gl_FragColor = (texture2D(texture, vUv) * tintMul + tintAdd * texture2D(texture, vUv).a) * vColor;
+}

--- a/Source/Ejecta/EJSharedOpenGLContext.h
+++ b/Source/Ejecta/EJSharedOpenGLContext.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "EJGLProgram2D.h"
 #import "EJGLProgram2DRadialGradient.h"
+#import "EJGLProgram2DTint.h"
 
 #define EJ_OPENGL_VERTEX_BUFFER_SIZE (32 * 1024) // 32kb
 
@@ -10,6 +11,7 @@
 	EJGLProgram2D *glProgram2DAlphaTexture;
 	EJGLProgram2D *glProgram2DPattern;
 	EJGLProgram2DRadialGradient *glProgram2DRadialGradient;
+	EJGLProgram2DTint *glProgram2DTint;
 	
 	EAGLContext *glContext2D;
 	EAGLSharegroup *glSharegroup;
@@ -23,6 +25,7 @@
 @property (nonatomic, readonly) EJGLProgram2D *glProgram2DAlphaTexture;
 @property (nonatomic, readonly) EJGLProgram2D *glProgram2DPattern;
 @property (nonatomic, readonly) EJGLProgram2DRadialGradient *glProgram2DRadialGradient;
+@property (nonatomic, readonly) EJGLProgram2DTint *glProgram2DTint;
 
 @property (nonatomic, readonly) EAGLContext *glContext2D;
 @property (nonatomic, readonly) EAGLSharegroup *glSharegroup;

--- a/Source/Ejecta/EJSharedOpenGLContext.m
+++ b/Source/Ejecta/EJSharedOpenGLContext.m
@@ -7,6 +7,7 @@
 @synthesize glProgram2DAlphaTexture;
 @synthesize glProgram2DPattern;
 @synthesize glProgram2DRadialGradient;
+@synthesize glProgram2DTint;
 @synthesize glContext2D;
 @synthesize glSharegroup;
 
@@ -34,6 +35,7 @@ static EJSharedOpenGLContext *sharedOpenGLContext;
 	[glProgram2DAlphaTexture release];
 	[glProgram2DPattern release];
 	[glProgram2DRadialGradient release];
+	[glProgram2DTint release];
 	[glContext2D release];
 	[vertexBuffer release];
 	
@@ -61,6 +63,7 @@ EJ_GL_PROGRAM_GETTER(EJGLProgram2D, Texture);
 EJ_GL_PROGRAM_GETTER(EJGLProgram2D, AlphaTexture);
 EJ_GL_PROGRAM_GETTER(EJGLProgram2D, Pattern);
 EJ_GL_PROGRAM_GETTER(EJGLProgram2DRadialGradient, RadialGradient);
+EJ_GL_PROGRAM_GETTER(EJGLProgram2DTint, Tint);
 
 #undef EJ_GL_PROGRAM_GETTER
 


### PR DESCRIPTION
Hi there!

I'm proposing this PR to start a discussion about shader integration.
Ejecta is a great tool but it would be nice to push things a bit further to fully enjoy hardware acceleration.

The code I pushed allows devs to integrate and use new fragment shaders more easily and manage them directly from the JS part.

A simple code such as the one following allows to apply tints on any Image or Canvas:

```
var w = window.innerWidth;
var h = window.innerHeight;

var canvas = document.getElementById('canvas');
canvas.width = w;
canvas.height = h;

var ctx = canvas.getContext('2d');

var img = new Image();
var imageLoaded = false;
img.onload = function () {
    imageLoaded = true;
};
img.src = "path/image.png";

// The new part
var material = new Ejecta.Material();
material.shader = "Tint";
material.setUniform("tintAdd", "glUniform4f", [ 0.0, 0.0, 0.4, 0.0 ] );
material.setUniform("tintMul", "glUniform4f", [ 0.5, 0.5, 2.0, 1.0 ] );
img.material = material;

var animate = function() {
if(imageLoaded) {
        ctx.drawImage(img, 0, 0);
    }
};

setInterval( animate, 16 );
```

Any thought or ideas on this? A special architecture wanted based on particular specifications?

What could be nice would be to just have to drop a new shader on the 'Shaders' folder instead of having to additionally create an appropriate class natively for each new shader. It could be done too.
