### PR TITLE
fix getUniformLocation return NULL when uniform location is -1

### DIFF
--- a/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
@@ -1188,6 +1188,8 @@ EJ_BIND_FUNCTION(getUniformLocation, ctx, argc, argv) {
 	NSString *name = JSValueToNSString(ctx, argv[1]);
 	
 	GLuint uniform = glGetUniformLocation(program, [name UTF8String]);
+	if (uniform == -1)
+		return NULL;
 	return [EJBindingWebGLUniformLocation createJSObjectWithContext:ctx
 		scriptView:scriptView webglContext:self index:uniform];
 }


### PR DESCRIPTION
According to http://www.khronos.org/registry/webgl/specs/latest/1.0/, getUniformLocation should return NULL in some cases.

This fix make getUniformLocation return NULL when the OpenGL call returns -1.
