### PR TITLE
fix the size of iAd banner in iPad under landscape

### DIFF
--- a/Source/Ejecta/EJUtils/EJBindingAdBanner.m
+++ b/Source/Ejecta/EJUtils/EJBindingAdBanner.m
@@ -28,7 +28,7 @@
                                            : ADBannerContentSizeIdentifierPortrait);
 	// for iOS 6 later
 	CGSize adSize = [banner sizeThatFits:scriptView.bounds.size];
-	[banner setFrame:CGRectMake(0, 0, adSize.width, adSize.height);];
+	[banner setFrame:CGRectMake(0, 0, adSize.width, adSize.height)];
     
 	[scriptView addSubview:banner];
 	NSLog(@"AdBanner: init at y %f", banner.frame.origin.y);


### PR DESCRIPTION
there is a bug:  in landscape iPad (test on iOS 6.13),  the iAd banner's width is always 768px .

and in new iOS , the apple suggest to use sizeThatFits , so I pull this request.
