### PR TITLE
Add the four missing globalCompositeModes

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
@@ -39,7 +39,11 @@ EJ_BIND_ENUM(globalCompositeOperation, renderingContext.globalCompositeOperation
 	"destination-over",	// kEJCompositeOperationDestinationOver
 	"source-atop",		// kEJCompositeOperationSourceAtop
 	"xor",				// kEJCompositeOperationXOR
-	"copy"				// kEJCompositeOperationCopy
+	"copy",				// kEJCompositeOperationCopy
+	"source-in",		// kEJCompositeOperationSourceIn
+	"destination-in",	// kEJCompositeOperationDestinationIn
+	"source-out",		// kEJCompositeOperationSourceOut
+	"destination-atop"	// kEJCompositeOperationDestinationAtop
 );
 
 EJ_BIND_ENUM(lineCap, renderingContext.state->lineCap,

--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.h
@@ -47,7 +47,11 @@ typedef enum {
 	kEJCompositeOperationDestinationOver,
 	kEJCompositeOperationSourceAtop,
 	kEJCompositeOperationXOR,
-	kEJCompositeOperationCopy
+	kEJCompositeOperationCopy,
+	kEJCompositeOperationSourceIn,
+	kEJCompositeOperationDestinationIn,
+	kEJCompositeOperationSourceOut,
+	kEJCompositeOperationDestinationAtop
 } EJCompositeOperation;
 
 typedef struct { GLenum source; GLenum destination; float alphaFactor; } EJCompositeOperationFunc;

--- a/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJCanvasContext2D.m
@@ -15,7 +15,11 @@ const EJCompositeOperationFunc EJCompositeOperationFuncs[] = {
 	[kEJCompositeOperationDestinationOver] = {GL_ONE_MINUS_DST_ALPHA, GL_ONE, 1},
 	[kEJCompositeOperationSourceAtop] = {GL_DST_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1},
 	[kEJCompositeOperationXOR] = {GL_ONE_MINUS_DST_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1},
-	[kEJCompositeOperationCopy] = {GL_ONE, GL_ZERO, 1}
+	[kEJCompositeOperationCopy] = {GL_ONE, GL_ZERO, 1},
+	[kEJCompositeOperationSourceIn] = {GL_DST_ALPHA, GL_ZERO, 1},
+	[kEJCompositeOperationDestinationIn] = {GL_ZERO, GL_SRC_ALPHA, 1},
+	[kEJCompositeOperationSourceOut] = {GL_ONE_MINUS_DST_ALPHA, GL_ZERO, 1},
+	[kEJCompositeOperationDestinationAtop] = {GL_ONE_MINUS_DST_ALPHA, GL_SRC_ALPHA, 1}
 };
 
 


### PR DESCRIPTION
Add support for the missing composite modes source-in, destination-in, source-out and destination-atop to the canvas 2D context.
