### PR TITLE
Create interceptor-system for Ejecta

### DIFF
--- a/Ejecta.xcodeproj/project.pbxproj
+++ b/Ejecta.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		3EBC19BE16CECE190036F9F3 /* EJBindingKeyInput.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBC19BD16CECE190036F9F3 /* EJBindingKeyInput.m */; };
 		3EF00C5916C29360004599A4 /* EJJavaScriptView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EF00C5816C29360004599A4 /* EJJavaScriptView.m */; };
 		5B7B76761619DB9700691910 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7B76751619DB9700691910 /* CoreText.framework */; };
+		5C631C0F19114DAD009AF7F0 /* EJBindingDecryptorXOR.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C631C0E19114DAD009AF7F0 /* EJBindingDecryptorXOR.m */; };
+		5C631C1519115470009AF7F0 /* EJBindingBaseInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C631C1119115470009AF7F0 /* EJBindingBaseInterceptor.m */; };
+		5C631C1619115470009AF7F0 /* EJInterceptorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C631C1419115470009AF7F0 /* EJInterceptorManager.m */; };
 		B6074FF315F8E41700D987F9 /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6074FF215F8E41600D987F9 /* GameKit.framework */; };
 		B607AB67132EA6C300D7C3EA /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B607AB66132EA6C300D7C3EA /* OpenAL.framework */; };
 		B607AC33132EA75F00D7C3EA /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B607AC32132EA75F00D7C3EA /* AudioToolbox.framework */; };
@@ -132,6 +135,13 @@
 		3EF00C5716C29360004599A4 /* EJJavaScriptView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJJavaScriptView.h; sourceTree = "<group>"; };
 		3EF00C5816C29360004599A4 /* EJJavaScriptView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJJavaScriptView.m; sourceTree = "<group>"; };
 		5B7B76751619DB9700691910 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		5C631C0D19114DAD009AF7F0 /* EJBindingDecryptorXOR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJBindingDecryptorXOR.h; sourceTree = "<group>"; };
+		5C631C0E19114DAD009AF7F0 /* EJBindingDecryptorXOR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJBindingDecryptorXOR.m; sourceTree = "<group>"; };
+		5C631C1019115470009AF7F0 /* EJBindingBaseInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJBindingBaseInterceptor.h; sourceTree = "<group>"; };
+		5C631C1119115470009AF7F0 /* EJBindingBaseInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJBindingBaseInterceptor.m; sourceTree = "<group>"; };
+		5C631C1219115470009AF7F0 /* EJInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJInterceptor.h; sourceTree = "<group>"; };
+		5C631C1319115470009AF7F0 /* EJInterceptorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EJInterceptorManager.h; sourceTree = "<group>"; };
+		5C631C1419115470009AF7F0 /* EJInterceptorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EJInterceptorManager.m; sourceTree = "<group>"; };
 		B6074FF215F8E41600D987F9 /* GameKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameKit.framework; path = System/Library/Frameworks/GameKit.framework; sourceTree = SDKROOT; };
 		B607AB66132EA6C300D7C3EA /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
 		B607AC32132EA75F00D7C3EA /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -351,6 +361,7 @@
 			isa = PBXGroup;
 			children = (
 				B68C5AEF132E6CD60015092E /* App */,
+				5C631C0C19114DAD009AF7F0 /* Extension */,
 				B64CE60E166682700087CF94 /* Source */,
 				B64CE683166682B10087CF94 /* Resources */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
@@ -386,6 +397,27 @@
 				B6AC4A051359E7A5003C4982 /* iAd.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5C631C0419114B11009AF7F0 /* EJInterceptor */ = {
+			isa = PBXGroup;
+			children = (
+				5C631C1019115470009AF7F0 /* EJBindingBaseInterceptor.h */,
+				5C631C1119115470009AF7F0 /* EJBindingBaseInterceptor.m */,
+				5C631C1219115470009AF7F0 /* EJInterceptor.h */,
+				5C631C1319115470009AF7F0 /* EJInterceptorManager.h */,
+				5C631C1419115470009AF7F0 /* EJInterceptorManager.m */,
+			);
+			path = EJInterceptor;
+			sourceTree = "<group>";
+		};
+		5C631C0C19114DAD009AF7F0 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				5C631C0D19114DAD009AF7F0 /* EJBindingDecryptorXOR.h */,
+				5C631C0E19114DAD009AF7F0 /* EJBindingDecryptorXOR.m */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		B609F2CB16AD873900A3B2B9 /* Shaders */ = {
@@ -429,6 +461,7 @@
 			children = (
 				B64CE612166682700087CF94 /* EJAudio */,
 				B64CE624166682700087CF94 /* EJCanvas */,
+				5C631C0419114B11009AF7F0 /* EJInterceptor */,
 				B64CE642166682700087CF94 /* EJUtils */,
 				B64CE610166682700087CF94 /* EJAppViewController.h */,
 				B64CE611166682700087CF94 /* EJAppViewController.m */,
@@ -767,7 +800,10 @@
 				B6F114FF1676BD40001F1324 /* EJFont.mm in Sources */,
 				B668475C182419A500ABCDF9 /* EJCanvasContextWebGLScreen.m in Sources */,
 				B6F115001676BD40001F1324 /* EJImageData.m in Sources */,
+				5C631C0F19114DAD009AF7F0 /* EJBindingDecryptorXOR.m in Sources */,
 				B6F115011676BD40001F1324 /* EJPath.mm in Sources */,
+				5C631C1619115470009AF7F0 /* EJInterceptorManager.m in Sources */,
+				5C631C1519115470009AF7F0 /* EJBindingBaseInterceptor.m in Sources */,
 				B6F115061676BE18001F1324 /* EJConvertColorRGBA.m in Sources */,
 				B6F1151A1677F08A001F1324 /* EJBindingDeviceMotion.m in Sources */,
 				B6F1154D167A7D17001F1324 /* EJBindingCanvasContextWebGL.m in Sources */,

--- a/Extension/EJBindingDecryptorXOR.h
+++ b/Extension/EJBindingDecryptorXOR.h
@@ -1,0 +1,9 @@
+#import "EJBindingBaseInterceptor.h"
+
+//Please Don't change the value of EJ_SECRET_HEADER, unless you understand it.
+#define EJ_SECRET_HEADER @"=S="
+#define EJ_SECRET_KEY @"SecretKey (Don't include Breakline)"
+
+@interface EJBindingDecryptorXOR : EJBindingBaseInterceptor
+
+@end

--- a/Extension/EJBindingDecryptorXOR.m
+++ b/Extension/EJBindingDecryptorXOR.m
@@ -1,0 +1,39 @@
+#import "EJBindingDecryptorXOR.h"
+
+@implementation EJBindingDecryptorXOR
+
+
+-(void)interceptData:(NSMutableData *)data {
+    
+    if (!data){
+        return;
+    }
+    
+	NSData *headData = [EJ_SECRET_HEADER dataUsingEncoding:NSUTF8StringEncoding];
+	size_t headLen = headData.length;
+	char const *head = headData.bytes;
+
+    char const *bytes = data.bytes;
+	for (int i = 0; i < headLen; i++) {
+		if (bytes[i]!=head[i]){
+            return;
+        };
+	}
+    
+    NSData *keyData = [EJ_SECRET_KEY dataUsingEncoding:NSUTF8StringEncoding];
+	size_t keyLen = keyData.length;
+	char const *key = keyData.bytes;
+    
+    NSRange range = NSMakeRange(0, headLen);
+    [data replaceBytesInRange:range withBytes:NULL length:0];
+    size_t dataSize = data.length;
+    char *mutableBytes = data.mutableBytes;
+    
+	for (int i = 0; i < dataSize; i++) {
+		char v = bytes[i];
+        char kv = key[i % keyLen];
+		mutableBytes[i] = v ^ kv;
+	}
+}
+
+@end

--- a/Source/Ejecta/EJAudio/EJAudioSourceAVAudio.h
+++ b/Source/Ejecta/EJAudio/EJAudioSourceAVAudio.h
@@ -3,10 +3,14 @@
 
 #import "EJAudioSource.h"
 
+#import "EJInterceptorManager.h"
+
 @interface EJAudioSourceAVAudio : NSObject <EJAudioSource, AVAudioPlayerDelegate> {
 	NSString *path;
 	AVAudioPlayer *player;
 	NSObject<EJAudioSourceDelegate> *delegate;
+    
+    EJInterceptorManager *interceptorManager;
 }
 
 @property (nonatomic) float currentTime;

--- a/Source/Ejecta/EJAudio/EJAudioSourceAVAudio.m
+++ b/Source/Ejecta/EJAudio/EJAudioSourceAVAudio.m
@@ -8,7 +8,16 @@
 - (id)initWithPath:(NSString *)pathp {
 	if( self = [super init] ) {
 		path = [pathp retain];
-		player = [[AVAudioPlayer alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:nil];
+
+		interceptorManager = [[EJInterceptorManager instance] retain];
+
+		NSMutableData *data = [NSMutableData dataWithContentsOfURL:[NSURL fileURLWithPath:path]];
+		if( !data ) {
+			NSLog(@"Error Loading audio %@ - not found.", path);
+			return NULL;
+		}
+		[interceptorManager interceptData:AFTER_LOAD_AUDIO data:data];
+		player = [[AVAudioPlayer alloc] initWithData:data error:nil];
 		player.delegate = self;
 	}
 	return self;
@@ -17,7 +26,7 @@
 - (void)dealloc {
 	[path release];
 	[player release];
-	
+	[interceptorManager release];
 	[super dealloc];
 }
 

--- a/Source/Ejecta/EJCanvas/EJTexture.h
+++ b/Source/Ejecta/EJCanvas/EJTexture.h
@@ -4,6 +4,7 @@
 #import <OpenGLES/ES1/glext.h>
 
 #import "EJTextureStorage.h"
+#import "EJInterceptorManager.h"
 
 @interface EJTexture : NSObject <NSCopying> {
 	BOOL cached;
@@ -19,6 +20,8 @@
 	
 	EJTextureParams params;
 	NSBlockOperation *loadCallback;
+    
+	EJInterceptorManager *interceptorManager;
 }
 - (id)initEmptyForWebGL;
 - (id)initWithPath:(NSString *)path;

--- a/Source/Ejecta/EJInterceptor/EJBindingBaseInterceptor.h
+++ b/Source/Ejecta/EJInterceptor/EJBindingBaseInterceptor.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import "EJBindingBase.h"
+#import "EJInterceptorManager.h"
+#import "EJInterceptor.h"
+
+@interface EJBindingBaseInterceptor : EJBindingBase<EJInterceptor> {
+	EJInterceptorManager *interceptorManager;
+    NSString *name;
+}
+
+
+
+@end

--- a/Source/Ejecta/EJInterceptor/EJBindingBaseInterceptor.m
+++ b/Source/Ejecta/EJInterceptor/EJBindingBaseInterceptor.m
@@ -1,0 +1,65 @@
+#import "EJBindingBaseInterceptor.h"
+
+@implementation EJBindingBaseInterceptor
+
+
+- (id)initWithContext:(JSContextRef)ctx argc:(size_t)argc argv:(const JSValueRef[])argv {
+	if (self = [super initWithContext:ctx argc:argc argv:argv]) {
+        
+        interceptorManager = [[EJInterceptorManager instance] retain];
+
+		if (argc > 0) {
+			name = [JSValueToNSString(ctx, argv[0]) retain];
+            if ([interceptorManager hasInterceptor:name]){
+                NSLog(@"Error: Duplicate interceptor name: %@",name);
+            }
+		}
+		else {
+			NSLog(@"Error: Must set interceptor name.");
+		}
+	}
+
+	return self;
+}
+
+
+- (void)dealloc {
+    [self disable];
+	[interceptorManager release];
+	[super dealloc];
+}
+
+- (void)enable {
+    [interceptorManager setInterceptor:name interceptor:self];
+}
+
+- (void)disable {
+    [interceptorManager removeInterceptor:name];
+}
+
+
+- (void)interceptData:(NSMutableData *)data {
+    
+    NSLog(@"Please impletment interceptor.interceptData(data) .");
+    
+}
+
+EJ_BIND_GET(name, ctx)
+{
+    return NSStringToJSValue(ctx, name);
+}
+
+EJ_BIND_FUNCTION(enable, ctx, argc, argv)
+{
+    [self enable];
+	return NULL;
+}
+
+EJ_BIND_FUNCTION(disable, ctx, argc, argv)
+{
+    [self disable];
+	return NULL;
+}
+
+
+@end

--- a/Source/Ejecta/EJInterceptor/EJInterceptor.h
+++ b/Source/Ejecta/EJInterceptor/EJInterceptor.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+
+@protocol EJInterceptor
+
+@required
+- (void)interceptData:(NSMutableData *)data;
+
+
+@end

--- a/Source/Ejecta/EJInterceptor/EJInterceptorManager.h
+++ b/Source/Ejecta/EJInterceptor/EJInterceptorManager.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+#define AFTER_LOAD_JS @"afterLoadJS"
+#define AFTER_LOAD_IMAGE @"afterLoadImage"
+#define AFTER_LOAD_AUDIO @"afterLoadAudio"
+
+@interface EJInterceptorManager : NSObject {
+	NSMutableDictionary *interceptors;
+}
+
++ (EJInterceptorManager *)instance;
+
+- (void)setInterceptor:(NSString *)name interceptor:(id)interceptor;
+- (id)getInterceptor:(NSString *)name;
+- (void)removeInterceptor:(NSString *)name;
+- (BOOL)hasInterceptor:(NSString *)name;
+- (NSArray *)getAllInterceptorNames;
+
+
+- (void)interceptData:(NSString *)interceptorName data:(NSMutableData *)data;
+
+
+@end

--- a/Source/Ejecta/EJInterceptor/EJInterceptorManager.m
+++ b/Source/Ejecta/EJInterceptor/EJInterceptorManager.m
@@ -1,0 +1,55 @@
+#import "EJInterceptorManager.h"
+#import "EJInterceptor.h"
+
+@implementation EJInterceptorManager
+
+static EJInterceptorManager *interceptorManager;
+
++ (EJInterceptorManager *)instance {
+	if (!interceptorManager) {
+		interceptorManager = [[[EJInterceptorManager alloc] init] autorelease];
+	}
+	return interceptorManager;
+}
+
+- (id)init {
+	if (self = [super init]) {
+		interceptors = [[NSMutableDictionary alloc] init];
+	}
+	return self;
+}
+
+- (void)dealloc {
+	interceptorManager = nil;
+	[interceptors release];
+	[super dealloc];
+}
+
+- (void)setInterceptor:(NSString *)name interceptor:(id)interceptor {
+	[interceptors setObject:interceptor forKey:name];
+}
+
+- (id)getInterceptor:(NSString *)name {
+	return [interceptors objectForKey:name];
+}
+
+- (void)removeInterceptor:(NSString *)name {
+	[interceptors removeObjectForKey:name];
+}
+
+- (BOOL)hasInterceptor:(NSString *)name {
+	return [self getInterceptor:name] != nil;
+}
+
+- (NSArray *)getAllInterceptorNames {
+	return [interceptors allKeys];
+}
+
+- (void)interceptData:(NSString *)interceptorName data:(NSMutableData *)data {
+	id interceptor = [self getInterceptor:interceptorName];
+	if (interceptor && [interceptor conformsToProtocol:@protocol(EJInterceptor)]) {
+		[interceptor interceptData:data];
+	}
+}
+
+@end

--- a/Source/Ejecta/EJJavaScriptView.h
+++ b/Source/Ejecta/EJJavaScriptView.h
@@ -10,6 +10,8 @@
 #import "EJSharedOpenGLContext.h"
 #import "EJNonRetainingProxy.h"
 
+#import "EJInterceptorManager.h"
+
 #define EJECTA_VERSION @"1.5"
 #define EJECTA_DEFAULT_APP_FOLDER @"App/"
 
@@ -65,6 +67,8 @@
 
 	NSOperationQueue *backgroundQueue;
 	JSClassRef jsBlockFunctionClass;
+	
+	EJInterceptorManager *interceptorManager;
 	
 	// Public for fast access in bound functions
 	@public JSValueRef jsUndefined;

--- a/Source/Ejecta/EJJavaScriptView.m
+++ b/Source/Ejecta/EJJavaScriptView.m
@@ -53,6 +53,8 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 		appFolder = [folder retain];
 		
 		isPaused = false;
+		
+		interceptorManager = [[EJInterceptorManager instance] retain];
 
 		// CADisplayLink (and NSNotificationCenter?) retains it's target, but this
 		// is causing a retain loop - we can't completely release the scriptView
@@ -141,6 +143,9 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 	[openGLContext release];
 	[appFolder release];
 	[proxy release];
+	
+	[interceptorManager release];
+	
 	[super dealloc];
 }
 
@@ -200,9 +205,13 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 }
 
 - (void)loadScriptAtPath:(NSString *)path {
-	NSString *script = [NSString stringWithContentsOfFile:[self pathForResource:path]
-		encoding:NSUTF8StringEncoding error:NULL];
 	
+	NSMutableData *fileData = [NSMutableData dataWithContentsOfFile:[self pathForResource:path]];
+
+	[interceptorManager interceptData:AFTER_LOAD_JS data:fileData];
+
+	NSString* script = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
+	   
 	[self evaluateScript:script sourceURL:path];
 }
 
@@ -218,20 +227,20 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 		);
 		return NULL;
 	}
-    
+	
 	JSStringRef scriptJS = JSStringCreateWithCFString((CFStringRef)script);
 	JSStringRef sourceURLJS = NULL;
-    
+	
 	if( [sourceURL length] > 0 ) {
 		sourceURLJS = JSStringCreateWithCFString((CFStringRef)sourceURL);
 	}
-    
+	
 	JSValueRef exception = NULL;
 	JSValueRef ret = JSEvaluateScript(jsGlobalContext, scriptJS, NULL, sourceURLJS, 0, &exception );
 	[self logException:exception ctx:jsGlobalContext];
 	
 	JSStringRelease( scriptJS );
-    
+	
 	if ( sourceURLJS ) {
 		JSStringRelease( sourceURLJS );
 	}
@@ -240,9 +249,13 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 
 - (JSValueRef)loadModuleWithId:(NSString *)moduleId module:(JSValueRef)module exports:(JSValueRef)exports {
 	NSString *path = [moduleId stringByAppendingString:@".js"];
-	NSString *script = [NSString stringWithContentsOfFile:[self pathForResource:path]
-		encoding:NSUTF8StringEncoding error:NULL];
+
+	NSMutableData *fileData = [NSMutableData dataWithContentsOfFile:[self pathForResource:path]];
 	
+	[interceptorManager interceptData:AFTER_LOAD_JS data:fileData];
+
+	NSString* script = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
+
 	if( !script ) {
 		NSLog(@"Error: Can't Find Module %@", moduleId );
 		return NULL;


### PR DESCRIPTION
This pull request is about #384

I don't use Event-pattern , instead ,   I choose interceptor.

The interceptor  could  process the data of  js file /image file/audio file , before they are be used in Ejecta.

If user  doesn't  create or enable  any interceptor ,  nothing will happen.
# 

Extension/EJBindingDecryptorXOR.m  is just a default   Decryptor-interceptor. 
It shows how to create and use an interceptor.

There is an example App  :  http://fattyboy.cn/App.zip

in this  App.zip  , there is an  Encryptor.js , it is used for encrypting files ,
then  when App is running ,  EJBindingDecryptorXOR will decryptor   encrypted files.
