### PR TITLE
Fix the bug about the circular reference between jsCanvas and jsContext

### DIFF
--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
@@ -24,11 +24,8 @@
 
 - (void)dealloc {	
 	[renderingContext release];
+	jsCanvas = nil;
 	[super dealloc];
-}
-
-EJ_BIND_GET(canvas, ctx) {
-	return jsCanvas;
 }
 
 EJ_BIND_ENUM(globalCompositeOperation, renderingContext.globalCompositeOperation,

--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
@@ -22,7 +22,8 @@
 	return self;
 }
 
-- (void)dealloc {	
+- (void)dealloc {
+	NSLog(@" -- context dealloc -- ");
 	[renderingContext release];
 	jsCanvas = nil;
 	[super dealloc];

--- a/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
+++ b/Source/Ejecta/EJCanvas/2D/EJBindingCanvasContext2D.m
@@ -23,7 +23,9 @@
 }
 
 - (void)dealloc {
+#if DEBUG
 	NSLog(@" -- context dealloc -- ");
+#endif
 	[renderingContext release];
 	jsCanvas = nil;
 	[super dealloc];

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -245,7 +245,7 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 		[binding release];
 	}
 	
-	[self addCanvasToContext];
+	[self linkCanvasAndContext];
 	
 	contextMode = newContextMode;
 	
@@ -260,10 +260,14 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 	return jsCanvasContext;
 }
 
-- (void)addCanvasToContext{
+- (void)linkCanvasAndContext {
 	JSStringRef canvasName = JSStringCreateWithUTF8CString("canvas");
 	JSObjectSetProperty(scriptView.jsGlobalContext, jsCanvasContext, canvasName, jsObject, kJSPropertyAttributeReadOnly, NULL);
 	JSStringRelease(canvasName);
+	
+	JSStringRef contextName = JSStringCreateWithUTF8CString("__context");
+	JSObjectSetProperty(scriptView.jsGlobalContext, jsObject, contextName, jsCanvasContext, kJSPropertyAttributeDontEnum, NULL);
+	JSStringRelease(contextName);
 }
 
 - (JSValueRef)toDataURLWithCtx:(JSContextRef)ctx argc:(size_t)argc argv:(const JSValueRef [])argv hd:(BOOL)hd {

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -41,6 +41,8 @@
 }
 
 - (void)dealloc {
+	NSLog(@" ===== canvas dealloc: %d, %d ===== ",width,height);
+	
 	if( isScreenCanvas ) {
 		scriptView.hasScreenCanvas = NO;
 	}
@@ -217,7 +219,6 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 			initWithCanvas:jsObject renderingContext:(EJCanvasContext2D *)renderingContext];
 		jsCanvasContext = [EJBindingCanvasContext2D createJSObjectWithContext:ctx scriptView:scriptView instance:binding];
 		[binding release];
-		JSValueProtect(ctx, jsCanvasContext);
 	}
 	
 	// WebGL Screen or Texture
@@ -243,9 +244,9 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 			initWithCanvas:jsObject renderingContext:(EJCanvasContextWebGL *)renderingContext];
 		jsCanvasContext = [EJBindingCanvasContextWebGL createJSObjectWithContext:ctx scriptView:scriptView instance:binding];
 		[binding release];
-		JSValueProtect(ctx, jsCanvasContext);
 	}
 	
+	[self addCanvasToContext];
 	
 	contextMode = newContextMode;
 	
@@ -258,6 +259,12 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 	
 	
 	return jsCanvasContext;
+}
+
+- (void)addCanvasToContext{
+	JSStringRef canvasName = JSStringCreateWithUTF8CString("canvas");
+	JSObjectSetProperty(scriptView.jsGlobalContext, jsCanvasContext, canvasName, jsObject, kJSPropertyAttributeReadOnly, NULL);
+	JSStringRelease(canvasName);
 }
 
 - (JSValueRef)toDataURLWithCtx:(JSContextRef)ctx argc:(size_t)argc argv:(const JSValueRef [])argv hd:(BOOL)hd {

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -41,8 +41,9 @@
 }
 
 - (void)dealloc {
+#if DEBUG
 	NSLog(@" -- canvas dealloc: %d, %d -- ",width,height);
-	
+#endif
 	if( isScreenCanvas ) {
 		scriptView.hasScreenCanvas = NO;
 	}

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -41,14 +41,13 @@
 }
 
 - (void)dealloc {
-	NSLog(@" ===== canvas dealloc: %d, %d ===== ",width,height);
+	NSLog(@" -- canvas dealloc: %d, %d -- ",width,height);
 	
 	if( isScreenCanvas ) {
 		scriptView.hasScreenCanvas = NO;
 	}
 	[renderingContext release];
-	JSValueUnprotectSafe(scriptView.jsGlobalContext, jsCanvasContext);
-	
+
 	JSValueUnprotectSafe(scriptView.jsGlobalContext, styleObject.jsObject);
 	styleObject.binding = nil;
 	[styleObject release];

--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -262,11 +262,11 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 
 - (void)linkCanvasAndContext {
 	JSStringRef canvasName = JSStringCreateWithUTF8CString("canvas");
-	JSObjectSetProperty(scriptView.jsGlobalContext, jsCanvasContext, canvasName, jsObject, kJSPropertyAttributeReadOnly, NULL);
+	JSObjectSetProperty(scriptView.jsGlobalContext, jsCanvasContext, canvasName, jsObject, kJSPropertyAttributeReadOnly|kJSPropertyAttributeDontDelete, NULL);
 	JSStringRelease(canvasName);
 	
-	JSStringRef contextName = JSStringCreateWithUTF8CString("__context");
-	JSObjectSetProperty(scriptView.jsGlobalContext, jsObject, contextName, jsCanvasContext, kJSPropertyAttributeDontEnum, NULL);
+	JSStringRef contextName = JSStringCreateWithUTF8CString("__context__");
+	JSObjectSetProperty(scriptView.jsGlobalContext, jsObject, contextName, jsCanvasContext, kJSPropertyAttributeReadOnly|kJSPropertyAttributeDontEnum|kJSPropertyAttributeDontDelete, NULL);
 	JSStringRelease(contextName);
 }
 

--- a/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
@@ -70,6 +70,7 @@
 	[EAGLContext setCurrentContext:oldContext];
 	
 	[renderingContext release];
+	jsCanvas = nil;
 	
 	[super dealloc];
 }
@@ -141,10 +142,6 @@
 	}
 }
 
-
-EJ_BIND_GET(canvas, ctx) {
-	return jsCanvas;
-}
 
 EJ_BIND_GET(drawingBufferWidth, ctx) {
 	return JSValueMakeNumber(ctx, renderingContext.width * renderingContext.backingStoreRatio);

--- a/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
@@ -33,6 +33,7 @@
 }
 
 - (void)dealloc {
+	NSLog(@" -- context dealloc -- ");
 	// Make sure this rendering context is the current one, so all
 	// OpenGL objects can be deleted properly.
 	EAGLContext *oldContext = [EAGLContext currentContext];


### PR DESCRIPTION
fix #398 

test - case : 
```
var w = window.innerWidth;
var h = window.innerHeight;
var canvas = document.getElementById('canvas');
canvas.width = w;
canvas.height = h;
var context = canvas.getContext('2d');


function createCanvas(width, height) {
    var canvas = document.createElement("canvas");
    canvas.width = width;
    canvas.height = height;
    canvas.retinaResolutionEnabled = false;
    return canvas;
}

function createTempContexts(count) {
    count = count || 10
    for (var i = 0; i < count; i++) {
        var temp = createCanvas(1000, 1000);
        var ctx = temp.getContext("2d");
    }
}


var globalContextList = [];

function createGlobalCanvases(count) {
    count = count || 10
    for (var i = 0; i < count; i++) {
        var canvas = createCanvas(500, 500);
        var ctx = canvas.getContext("2d");
        globalContextList.push(ctx);
    }
}

createGlobalCanvases(40);
createTempContexts(40);

var pool = [];
setInterval(function() {
    // for eating memory
    var longString = (new Array(1000)).join("X")
    pool.push(longString);

    // Expected Result:
    // When recive memroy warning ,
    // The canvas of ctx be created in createTempContexts should be release (size 1000*1000).
    // BUT the canvas of ctx (in globalContextList) should NOT be release (size 500*500).

}, 20);


```
