### PR TITLE
Make landscape banners full-width

### DIFF
--- a/Source/Ejecta/EJUtils/EJBindingAdBanner.m
+++ b/Source/Ejecta/EJUtils/EJBindingAdBanner.m
@@ -22,6 +22,9 @@
 			? ADBannerContentSizeIdentifierLandscape
 			: ADBannerContentSizeIdentifierPortrait),
 		nil];
+ 	if( landscape ) {
+ 		banner.currentContentSizeIdentifier = ADBannerContentSizeIdentifierLandscape;
+ 	}
 	
 	[scriptView addSubview:banner];
 	NSLog(@"AdBanner: init at y %f", banner.frame.origin.y);


### PR DESCRIPTION
Set currentContentSizeIdentifier in landscape mode per 
https://developer.apple.com/library/ios/documentation/userexperience/Conceptual/iAd_Guide/BannerAdvertisements/BannerAdvertisements.html
