### PR TITLE
Remove needless 'break"  in EJBindingEjectaCore.m

### DIFF
--- a/Source/Ejecta/EJBindingEjectaCore.m
+++ b/Source/Ejecta/EJBindingEjectaCore.m
@@ -214,7 +214,7 @@ EJ_BIND_GET(orientation, ctx ) {
 		case UIInterfaceOrientationLandscapeLeft: angle = -90; break;
 		case UIInterfaceOrientationLandscapeRight: angle = 90; break;
 		case UIInterfaceOrientationPortraitUpsideDown: angle = 180; break;
-		default: angle = 0; break;
+		default: angle = 0;
 	}
 	return JSValueMakeNumber(ctx, angle);
 }


### PR DESCRIPTION
the `break;` after `default:` in Line 217 is needless
