### PR TITLE
Fix console.log & others to work more like expected

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -46,9 +46,12 @@ window.canvas.type = 'canvas';
 
 // The console object
 window.console = {
-	log: function() {
-		var args = Array.prototype.join.call(arguments, ', ');
-		ej.log( args );
+	_log: function(level, args) {
+		var txt = level + ':';
+		for (var i = 0; i < args.length; i++) {
+			txt += ' ' + (typeof args[i] === 'string' ? args[i] : JSON.stringify(args[i]));
+		}
+		ej.log( txt );
 	},
 	
 	assert: function() {
@@ -59,12 +62,12 @@ window.console = {
 		}
 	}
 };
-window.console.debug =
-	window.console.info =
-	window.console.warn =
-	window.console.error =
-	window.console.log;
-	
+window.console.debug = function () { window.console._log('DEBUG', arguments); };
+window.console.info =  function () { window.console._log('INFO', arguments); };
+window.console.warn =  function () { window.console._log('WARN', arguments); };
+window.console.error = function () { window.console._log('ERROR', arguments); };
+window.console.log =   function () { window.console._log('LOG', arguments); };
+
 var consoleTimers = {};
 console.time = function(name) {
 	consoleTimers[name] = ej.performanceNow();


### PR DESCRIPTION
This PR will allow JS console.log (or console.warn, etc.) to work more as expected.
Example below will now work fine:

``` javascript
var index = 5;
var map = { x: 3, y: 5 };
console.log("My map is:", map, "and index is", index);
```

Note that another way to write "_log" was as below but I find it a bit less readable and it is less efficient as well:

``` javascript
        var toStr = function (p) { return typeof p === 'string' ? p : JSON.stringify(p); }
        args = Array.prototype.slice.call(args, 0);
        var txt = args.map(toStr).join(' ');
```
