### PR TITLE
Handles cases where elements appended to the document do not implement tagName

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -152,7 +152,7 @@ HTMLElement.prototype.appendChild = function( element ) {
 	this.children.push( element );
 	
 	// If the child is a script element, begin to load it
-	if( element.tagName.toLowerCase() == 'script' ) {
+	if( element.tagName && element.tagName.toLowerCase() == 'script' ) {
 		ej.setTimeout( function(){
 			ej.include( element.src );
 			if( element.onload ) {


### PR DESCRIPTION
This simple fix enables pixi.js 1.6.1 to run on top of ejecta.
