### PR TITLE
[IAP] Fixes crash when deallocating IAPManager

### DIFF
--- a/Source/Ejecta/EJUtils/IAP/EJBindingIAPManager.m
+++ b/Source/Ejecta/EJUtils/IAP/EJBindingIAPManager.m
@@ -21,12 +21,12 @@
 }
 
 - (void)dealloc {
-	for( NSValue *v in productRequestCallbacks ) {
+	for( NSValue *v in productRequestCallbacks.allValues ) {
 		JSValueUnprotectSafe(scriptView.jsGlobalContext, v.pointerValue);
 	}
 	[productRequestCallbacks release];
 	
-	for( NSValue *v in products ) {
+	for( NSValue *v in products.allValues ) {
 		JSValueUnprotectSafe(scriptView.jsGlobalContext, v.pointerValue);
 	}
 	[products release];


### PR DESCRIPTION
This fixes an edge case in which the IAP manager would be deallocated:  
`productRequestCallbacks` and `products` are NDMuatbleDictionaries yet, when the IAP Manager is deallocated, they are traversed using fast enumeration directly on them which iterates through the dictionary's keys but the results of the enumeration are treated as the actual values rather than keys. This fix requests the values before running the fast enumeration.
