### PR TITLE
PIXI.js v3 expects canvas to support events

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.h
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.h
@@ -1,4 +1,4 @@
-#import "EJBindingBase.h"
+#import "EJBindingEventedBase.h"
 #import "EJTexture.h"
 #import "EJDrawable.h"
 #import "EJCanvasContext.h"
@@ -16,7 +16,7 @@ typedef enum {
 	kEJCanvasContextModeWebGL
 } EJCanvasContextMode;
 
-@interface EJBindingCanvas : EJBindingBase <EJDrawable> {
+@interface EJBindingCanvas : EJBindingEventedBase <EJDrawable> {
 	JSObjectRef jsCanvasContext;
 	EJCanvasContext *renderingContext;
 	EJCanvasContextMode contextMode;


### PR DESCRIPTION
In particular, PIXI.js v3 makes `addEventListener` calls on `canvas` element.

Note that this is a partial fix only to get past runtime errors. Firing canvas element events PIXI.js uses will complete the fix.