### PR TITLE
use ejecta.import to avoid re-including files

### DIFF
--- a/Source/Ejecta/EJBindingEjectaCore.m
+++ b/Source/Ejecta/EJBindingEjectaCore.m
@@ -75,6 +75,21 @@ EJ_BIND_FUNCTION(include, ctx, argc, argv ) {
 	return NULL;
 }
 
+EJ_BIND_FUNCTION(import, ctx, argc, argv ) {
+    static dispatch_once_t onceToken;
+    static NSMutableSet *_ejImports;
+    dispatch_once(&onceToken, ^{
+        _ejImports = [NSMutableSet new];
+    });
+    if( argc < 1 ) { return NULL; }
+    NSString *importName = JSValueToNSString(ctx, argv[0]);
+    if (![_ejImports containsObject:importName]){
+        [_ejImports addObject:importName];
+        [scriptView loadScriptAtPath:importName];
+    }
+    return NULL;
+}
+
 EJ_BIND_FUNCTION(loadFont, ctx, argc, argv ) {
 	if( argc < 1 ) { return NULL; }
 


### PR DESCRIPTION
similar to a C compiler's `#include` vs `#import`, `ejecta.include` can re-include a file, overwriting any existing vars or re-running any self executing anonymous functions (`(function(){...})();`). ejecta.import maintains a Set inside of iOS which will prevent re-inclusions. If you need to intentionally re-include a file, `ejecta.include` will still work fine in combination with `ejecta.import`. I'm hoping this will encourage using more distinct files instead of less monoliths.