### PR TITLE
Adds thread safety to HTTPRequest

### DIFF
--- a/Source/Ejecta/EJUtils/EJBindingHttpRequest.m
+++ b/Source/Ejecta/EJUtils/EJBindingHttpRequest.m
@@ -83,7 +83,9 @@
 	else {
 		completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
 		state = kEJHttpRequestStateDone;
-		[self triggerEvent:@"abort"];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self triggerEvent:@"abort"];
+        });
 		NSLog(@"XHR: Aborting Request %@ - wrong credentials", url);
 	}
 }
@@ -101,10 +103,12 @@
 	state = kEJHttpRequestStateDone;
 	
 	[session release]; session = NULL;
-	[self triggerEvent:@"load"];
-	[self triggerEvent:@"loadend"];
-	[self triggerEvent:@"readystatechange"];
-	JSValueUnprotectSafe(scriptView.jsGlobalContext, jsObject);
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [self triggerEvent:@"load"];
+        [self triggerEvent:@"loadend"];
+        [self triggerEvent:@"readystatechange"];
+        JSValueUnprotectSafe(scriptView.jsGlobalContext, jsObject);
+    });
 }
 
 - (void)didFailWithError:(NSError *)error {
@@ -112,14 +116,20 @@
 	
 	[session release]; session = NULL;
 	if( error.code == kCFURLErrorTimedOut ) {
-		[self triggerEvent:@"timeout"];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self triggerEvent:@"timeout"];
+        });
 	}
 	else {
-		[self triggerEvent:@"error"];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self triggerEvent:@"error"];
+        });
 	}
-	[self triggerEvent:@"loadend"];
-	[self triggerEvent:@"readystatechange"];
-	JSValueUnprotectSafe(scriptView.jsGlobalContext, jsObject);
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [self triggerEvent:@"loadend"];
+        [self triggerEvent:@"readystatechange"];
+        JSValueUnprotectSafe(scriptView.jsGlobalContext, jsObject);
+    });
 }
 
 - (void)didReceiveResponse:(NSURLResponse *)responsep {
@@ -128,14 +138,16 @@
 	[response release];
 	response = (NSHTTPURLResponse *)[responsep retain];
 	
-	JSContextRef ctx = scriptView.jsGlobalContext;
-	[self triggerEvent:@"progress" properties:(JSEventProperty[]){
-		{"lengthComputable", JSValueMakeBoolean(ctx, response.expectedContentLength != NSURLResponseUnknownLength)},
-		{"total", JSValueMakeNumber(ctx, response.expectedContentLength)},
-		{"loaded", JSValueMakeNumber(ctx, responseBody.length)},
-		{NULL, NULL}
-	}];
-	[self triggerEvent:@"readystatechange"];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        JSContextRef ctx = scriptView.jsGlobalContext;
+        [self triggerEvent:@"progress" properties:(JSEventProperty[]){
+            {"lengthComputable", JSValueMakeBoolean(ctx, response.expectedContentLength != NSURLResponseUnknownLength)},
+            {"total", JSValueMakeNumber(ctx, response.expectedContentLength)},
+            {"loaded", JSValueMakeNumber(ctx, responseBody.length)},
+            {NULL, NULL}
+        }];
+        [self triggerEvent:@"readystatechange"];
+    });
 }
 
 - (void)URLSession:(NSURLSession * _Nonnull)session
@@ -149,14 +161,16 @@
 	}
 	[responseBody appendData:data];
 	
-	JSContextRef ctx = scriptView.jsGlobalContext;
-	[self triggerEvent:@"progress" properties:(JSEventProperty[]){
-		{"lengthComputable", JSValueMakeBoolean(ctx, response.expectedContentLength != NSURLResponseUnknownLength)},
-		{"total", JSValueMakeNumber(ctx, response.expectedContentLength)},
-		{"loaded", JSValueMakeNumber(ctx, responseBody.length)},
-		{NULL, NULL}
-	}];
-	[self triggerEvent:@"readystatechange"];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        JSContextRef ctx = scriptView.jsGlobalContext;
+        [self triggerEvent:@"progress" properties:(JSEventProperty[]){
+            {"lengthComputable", JSValueMakeBoolean(ctx, response.expectedContentLength != NSURLResponseUnknownLength)},
+            {"total", JSValueMakeNumber(ctx, response.expectedContentLength)},
+            {"loaded", JSValueMakeNumber(ctx, responseBody.length)},
+            {NULL, NULL}
+        }];
+        [self triggerEvent:@"readystatechange"];
+    });
 }
 
 


### PR DESCRIPTION
The HTTPRequest class was recently refactored to use NSURLSession instead of NSURLConnection. The delegate callbacks for NSURLSession are performed in background threads, making it unsafe to call JavaScript and OpenGL from within those callbacks. At the moment, the JavaScript events associated with such callbacks are triggered from the background threads causing undefined behaviour on device.

This pull request makes use of GCD to dispatch the events from the main thread. Right now the events are dispatched synced but can easily be changed to be dispatched asynchronously but I am not sure if the code depends on being executed in order.