### PR TITLE
add allowsRotation to gamepad

### DIFF
--- a/Source/Ejecta/EJUtils/Gamepad/EJBindingGamepad.h
+++ b/Source/Ejecta/EJUtils/Gamepad/EJBindingGamepad.h
@@ -29,7 +29,8 @@ typedef enum {
 	
 	NSUInteger index;
 	BOOL connected;
-	
+    BOOL allowsRotation;
+
 	JSObjectRef jsAxes;
 	JSObjectRef jsButtons;
 }

--- a/Source/Ejecta/EJUtils/Gamepad/EJBindingGamepad.m
+++ b/Source/Ejecta/EJUtils/Gamepad/EJBindingGamepad.m
@@ -9,7 +9,7 @@
 		controller = [controllerp retain];
 		index = indexp;
 		connected = YES;
-		
+        allowsRotation = YES;
 		controller.playerIndex = index;
 	}
 	return self;
@@ -79,6 +79,7 @@
 		else if( controller.microGamepad ) {
 			GCMicroGamepad *gamepad = controller.microGamepad;
 			gamepad.reportsAbsoluteDpadValues = YES;
+            gamepad.allowsRotation = allowsRotation;
 			mapping[kEJGamepadButtonA] = gamepad.buttonA;
 			mapping[kEJGamepadButtonX] = gamepad.buttonX;
 			mapping[kEJGamepadButtonUp] = gamepad.dpad.up;
@@ -203,6 +204,19 @@ EJ_BIND_GET(exitOnMenuPress, ctx) {
 EJ_BIND_SET(exitOnMenuPress, ctx, value) {
 	scriptView.exitOnMenuPress = JSValueToBoolean(ctx, value);
 }
+
+EJ_BIND_GET(allowsRotation, ctx) {
+    return JSValueMakeBoolean(ctx, allowsRotation);
+}
+
+EJ_BIND_SET(allowsRotation, ctx, value) {
+    if( controller.microGamepad ) {
+        allowsRotation = JSValueToBoolean(ctx, value);
+        GCMicroGamepad *gamepad = controller.microGamepad;
+        gamepad.allowsRotation = allowsRotation;
+    }
+}
+
 
 @end
 


### PR DESCRIPTION
Users could set  gamepad.allowsRotation  by themselves  as same as exitOnMenuPress.

example:

```
    var gamepads = navigator.getGamepads();
    var gamepad = gamepads[1] || gamepads[0];
    if (!gamepad) {
        // console.log('No Gamepads connected');
        return;
    }

    gamepad.allowsRotation = true;
```

I think in Game ,  allowsRotation =true is more useful ,so default value is true.