### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ renderer = new THREE.WebGLRenderer( {canvas: document.getElementById('canvas')} 
 
 ## How to use
 
-1. Create a folder called `App` within this XCode project
+1. Create a folder called `App` within this Xcode project
 2. Copy your canvas application into the `App` folder
 3. Ensure you have at least 1 file named `index.js`
-4. Build the XCode project
+4. Build the Xcode project
 
 For an example application, copy `./index.js` into the `App` folder. An example App folder with the Three.js [Walt CubeMap demo](http://mrdoob.github.com/three.js/examples/webgl_materials_cubemap.html) can be found here:
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
