### PR TITLE
Add eval support for script tags

### DIFF
--- a/Source/Ejecta/Ejecta.js
+++ b/Source/Ejecta/Ejecta.js
@@ -204,17 +204,21 @@ HTMLElement = function( tagName ){
 HTMLElement.prototype.appendChild = function( element ) {
 	this.children.push( element );
 	
-	// If the child is a script element, begin to load it
+	// If the child is a script element, begin to load it or execute it
 	if( element.tagName && element.tagName.toLowerCase() == 'script' ) {
-		ej.setTimeout( function(){
-			ej.include( element.src );
-			if( element.onload ) {
-				element.onload({
-					type: 'load',
-					currentTarget: element
-				});
-			}
-		}, 1);
+		if ( element.src ) {
+			ej.setTimeout( function(){
+				ej.include( element.src );
+				if( element.onload ) {
+					element.onload({
+						type: 'load',
+						currentTarget: element
+					});
+				}
+			}, 1);
+		} else if( element.text ) {
+			window.eval( element.text );
+		}
 	}
 };
 


### PR DESCRIPTION
This commit adds support for eval-ing `script.text`.  This is a
requirement for Phaser when using their script preloading functionality.

Phaser loads scripts through XMLHttpRequest, then sets the responseText
to the script.text attribute.

More information can be seen here:

https://github.com/photonstorm/phaser/blob/47123c192df7f3a78ac25110a9a72b72f61417c2/src/loader/Loader.js#L2750-L2761