### PR TITLE
fix: enable 'alpha' option when getting webgl context

### DIFF
--- a/Source/Ejecta/EJCanvas/EJBindingCanvas.m
+++ b/Source/Ejecta/EJCanvas/EJBindingCanvas.m
@@ -215,6 +215,10 @@ EJ_BIND_FUNCTION(getContext, ctx, argc, argv) {
 				renderingContext.msaaEnabled = maxSamples > 1;
 				renderingContext.msaaSamples = MAX(2, MIN(maxSamples, msaaSamples));
 			}
+           
+			if ( !([options[@"alpha"] boolValue]) ) {
+					renderingContext.alphaShouldLock = YES;
+			}
 		}
 	}
 	

--- a/Source/Ejecta/EJCanvas/EJCanvasContext.h
+++ b/Source/Ejecta/EJCanvas/EJCanvasContext.h
@@ -9,6 +9,7 @@
 	
 	BOOL preserveDrawingBuffer;
 	BOOL msaaEnabled;
+	BOOL alphaShouldLock;
 	BOOL needsPresenting;
 	int msaaSamples;
 	EAGLContext *glContext;
@@ -20,6 +21,7 @@
 
 @property (nonatomic) BOOL preserveDrawingBuffer;
 @property (nonatomic) BOOL msaaEnabled;
+@property (nonatomic) BOOL alphaShouldLock;
 @property (nonatomic) int msaaSamples;
 @property (nonatomic) short width;
 @property (nonatomic) short height;

--- a/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJBindingCanvasContextWebGL.m
@@ -408,7 +408,17 @@ EJ_BIND_FUNCTION(clear, ctx, argc, argv) {
 EJ_BIND_FUNCTION_DIRECT(clearColor, glClearColor, red, green, blue, alpha);
 EJ_BIND_FUNCTION_DIRECT(clearDepth, glClearDepthf, depth);
 EJ_BIND_FUNCTION_DIRECT(clearStencil, glClearStencil, s);
-EJ_BIND_FUNCTION_DIRECT(colorMask, glColorMask, red, green, blue, alpha);
+EJ_BIND_FUNCTION(colorMask, ctx, argc, argv) {
+    if (argc != 4) { return NULL; }
+    
+    EJ_UNPACK_ARGV(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+    
+    if ([renderingContext alphaShouldLock]) {
+        alpha = GL_FALSE;
+    }
+    
+    glColorMask(red, green, blue, alpha);
+}
 
 EJ_BIND_FUNCTION(compileShader, ctx, argc, argv) {
 	if( argc < 1 ) { return NULL; }

--- a/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGL.m
@@ -59,6 +59,16 @@
 	needsPresenting = YES;
 }
 
+- (void) lockAlpha {
+    GLfloat c[4];
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, c);
+    // use current values for RGB，use GL_ONE for alpha
+    glClearColor(c[0], c[1], c[2], GL_ONE);
+    glClear(GL_COLOR_BUFFER_BIT);
+    // disable alpha channel
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+}
+
 - (void)create {
 	if( msaaEnabled ) {
 		glGenFramebuffers(1, &msaaFrameBuffer);

--- a/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGLScreen.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGLScreen.m
@@ -115,7 +115,10 @@
 	// Clear
 	glViewport(0, 0, width, height);
 	[self clear];
-	
+
+	if ([self alphaShouldLock]) {
+		[self lockAlpha];
+	}
 	
 	// Reset to the previously bound frame and renderbuffers
 	[self bindFramebuffer:previousFrameBuffer toTarget:GL_FRAMEBUFFER];

--- a/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGLTexture.m
+++ b/Source/Ejecta/EJCanvas/WebGL/EJCanvasContextWebGLTexture.m
@@ -41,6 +41,10 @@
 	// Clear
 	glViewport(0, 0, width, height);
 	[self clear];
+
+	if ([self alphaShouldLock]) {
+		[self lockAlpha];
+	}
 	
 	// Reset to the previously bound frame and renderbuffers
 	[self bindFramebuffer:previousFrameBuffer toTarget:GL_FRAMEBUFFER];


### PR DESCRIPTION
Enable 'alpha' option when getting webgl context.